### PR TITLE
Fix CI by adding @testing-library/react dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,9 @@ jobs:
       
       # Skip Docker build for now and focus on testing
       - name: Install dependencies
-        run: npm ci
+        run: |
+          npm ci
+          npm install --save-dev @testing-library/react
       
       # Run tests directly without Docker
       - name: Run linting and type checking

--- a/checkpoint.md
+++ b/checkpoint.md
@@ -1,85 +1,49 @@
 # DirectoryMonster GitHub CI Implementation
 
-## Current Status - CI Implementation Validated ✅
+## Current Status - CI Workflow Refinement In Progress
 
-We've successfully implemented, optimized, tested, and validated the GitHub CI workflow for the DirectoryMonster project. The workflow is now fully operational and integrated into the GitHub repository.
+We've successfully implemented and validated the GitHub CI workflow, and are now addressing the remaining issue with the workflow.
 
-### Completed Tasks
+### Current Progress
 
-1. **Fixed Failing Tests**:
-   - Added proper Jest test cases to the empty test file (tests/multitenant-integration.test.ts)
-   - Installed missing dependency (@testing-library/react) for LinkUtilities.test.tsx
-   - Modified test implementations to use proper mocking techniques
-   - Verified that all tests now pass consistently
+1. **Initial Implementation (Complete)**:
+   - Fixed failing tests (multitenant-integration.test.ts and LinkUtilities.test.tsx)
+   - Optimized CI workflow with caching and health checks
+   - Added documentation to the README
 
-2. **Optimized CI Workflow**:
-   - Added caching for npm dependencies to speed up installations
-   - Implemented Docker layer caching to reduce build times
-   - Improved container health checking with retries and proper timeouts
-   - Optimized test execution flow for better parallelization
+2. **Validation Testing (Complete)**:
+   - Created a test branch and PR
+   - Updated the upload-artifact action from v3 to v4
+   - Verified that the workflow runs in GitHub Actions
 
-3. **Fixed CI Compatibility Issues**:
-   - Updated the upload-artifact action from v3 to v4 to address GitHub Actions compatibility
-   - Fixed CI startup issues to ensure workflow runs properly in GitHub's environment
+3. **Final Fixes (In Progress)**:
+   - Identified that the @testing-library/react dependency is missing in the CI environment
+   - Created a fix by updating the workflow to install this dependency
+   - Submitted a PR to fix this issue
 
-4. **Validated CI Functionality**:
-   - Created a test PR to trigger the CI workflow
-   - Verified that the workflow runs successfully in GitHub Actions
-   - Confirmed that all steps are executing as expected
-   - Used GitHub CLI to monitor and debug workflow issues
+### Issues Found During Testing
 
-5. **Added Documentation**:
-   - Updated README with comprehensive CI process documentation
-   - Improved explanation of the CI workflow benefits and features
-   - Added instructions for viewing CI results in GitHub
+1. **Missing Dependencies**:
+   - One test (LinkUtilities.test.tsx) is still failing in the CI environment due to missing @testing-library/react dependency
+   - While we installed this dependency locally, it needs to be explicitly added to the CI workflow
 
-### Workflow Features
+2. **Workflow Optimization**:
+   - Simplified the workflow to focus on testing without the Docker complexity
+   - This approach is faster and more reliable for now
 
-The GitHub CI workflow now includes:
+### Next Steps
 
-1. **Environment Setup**:
-   - GitHub Actions runner on Ubuntu latest
-   - Docker Buildx for optimized container builds
-   - Caching for npm dependencies and Docker layers
-   - Host name resolution for domain-based tests
+1. **Merge the Fix PR**:
+   - PR #2 contains the fix for the missing dependency
+   - Once merged, the CI should pass all tests successfully
 
-2. **Container Management**:
-   - Docker image building with layer caching
-   - Container startup with health checking
-   - Redis integration for data persistence tests
+2. **Final Verification**:
+   - Run a final test on the main branch after merging
+   - Ensure all tests pass consistently
 
-3. **Testing Process**:
-   - Static analysis (linting and type checking)
-   - Unit testing with Jest
-   - Integration testing for multitenancy features
-   - Domain resolution and page rendering tests
-   - Comprehensive API endpoint testing
+3. **Future Improvements**:
+   - Reintroduce Docker testing once the basic workflow is stable
+   - Implement parallel testing for faster CI execution
+   - Increase test coverage beyond the current 6.78%
 
-4. **Logging and Diagnostics**:
-   - Detailed logging for all test steps
-   - Special handling for test failures
-   - Artifact uploads for post-run analysis
-   - Redis diagnostics for data persistence verification
-
-### Future Improvements
-
-1. **Test Coverage**: Current test coverage is low (6.78% overall).
-   - Next step: Implement more comprehensive tests for critical functionality.
-
-2. **Parallel Testing**: Consider splitting the test jobs into parallel workflows for even faster CI.
-   - Next step: Refactor the CI workflow to use GitHub Actions matrix strategy.
-
-3. **Environment-Specific Testing**: Add testing for different Node.js versions and environments.
-   - Next step: Implement a matrix strategy for multi-environment testing.
-
-4. **Deployment Automation**: Add automatic deployment to staging environments after CI passes.
-   - Next step: Implement deployment workflow for successful CI runs.
-
-5. **Performance Optimization**: Further optimize the CI workflow execution time.
-   - Next step: Analyze build and test times to identify bottlenecks.
-
-### Conclusion
-
-The GitHub CI workflow for DirectoryMonster is now fully operational and validated. It provides a solid foundation for automated testing and quality assurance. The implementation ensures that all code changes are tested before being merged into the main branch, helping to maintain high code quality and prevent regressions.
-
-Future work should focus on increasing test coverage, further optimizing the CI process, and potentially adding automated deployment capabilities.
+The GitHub CI workflow for DirectoryMonster is near completion. We've addressed all the original issues and identified new ones during validation. By fixing these issues, we're ensuring that the CI process is reliable and robust for all future development.


### PR DESCRIPTION
This PR fixes the CI workflow by adding the missing @testing-library/react dependency, which is required for the LinkUtilities.test.tsx test to pass.