### PR TITLE
Add tenant validation tests for category API

### DIFF
--- a/tests/unit/api/admin/categories/tenant-validation-simple.test.ts
+++ b/tests/unit/api/admin/categories/tenant-validation-simple.test.ts
@@ -1,0 +1,103 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { Category } from '@/types';
+
+// Mock the Redis client
+jest.mock('@/lib/redis-client', () => ({
+  kv: {
+    get: jest.fn(),
+    set: jest.fn(),
+    del: jest.fn(),
+    keys: jest.fn(),
+  }
+}));
+
+// Mock the middleware
+jest.mock('@/middleware/tenant-validation', () => ({
+  withTenantAccess: jest.fn().mockImplementation((req, handlerOrMiddleware) => {
+    // If handlerOrMiddleware is a function, call it directly
+    if (typeof handlerOrMiddleware === 'function') {
+      return handlerOrMiddleware(req);
+    }
+    // Otherwise, it's the result of another middleware, so call it with the request
+    return handlerOrMiddleware(req);
+  }),
+}));
+
+jest.mock('@/middleware/withPermission', () => ({
+  withResourcePermission: jest.fn().mockImplementation((req, resourceType, permission, handler) => {
+    // Return a function that will be called by withTenantAccess
+    return (validatedReq) => handler(validatedReq);
+  }),
+}));
+
+describe('Category API Tenant Validation', () => {
+  let mockGet: jest.Mock;
+  let mockSet: jest.Mock;
+  let mockDel: jest.Mock;
+
+  beforeEach(() => {
+    jest.resetModules();
+
+    // Get fresh mocks for each test
+    const { kv } = require('@/lib/redis-client');
+    mockGet = kv.get as jest.Mock;
+    mockSet = kv.set as jest.Mock;
+    mockDel = kv.del as jest.Mock;
+
+    // Clear all mocks
+    jest.clearAllMocks();
+  });
+
+  describe('GET /api/admin/categories/:id', () => {
+    it('should validate tenant ownership', async () => {
+      // Create a test category
+      const mockCategory: Category = {
+        id: 'test-category-id',
+        siteId: 'test-site',
+        tenantId: 'test-tenant',
+        name: 'Test Category',
+        slug: 'test-category',
+        metaDescription: 'Test category description',
+        order: 1,
+        createdAt: Date.now(),
+        updatedAt: Date.now()
+      };
+
+      // Mock the Redis get function to return our test category
+      mockGet.mockResolvedValue(mockCategory);
+
+      // Import the route handler
+      const { GET } = require('@/app/api/admin/categories/[id]/route');
+
+      // Test with matching tenant
+      const reqWithMatchingTenant = new NextRequest('https://example.com/api/admin/categories/test-category-id', {
+        headers: {
+          'x-tenant-id': 'test-tenant', // Same as category.tenantId
+          'authorization': 'Bearer test-token'
+        }
+      });
+
+      const responseWithMatchingTenant = await GET(reqWithMatchingTenant, { params: { id: 'test-category-id' } });
+      const responseDataWithMatchingTenant = await responseWithMatchingTenant.json();
+
+      // Should return the category when tenant matches
+      expect(responseWithMatchingTenant.status).toBe(200);
+      expect(responseDataWithMatchingTenant.category).toEqual(mockCategory);
+
+      // Test with different tenant
+      const reqWithDifferentTenant = new NextRequest('https://example.com/api/admin/categories/test-category-id', {
+        headers: {
+          'x-tenant-id': 'different-tenant', // Different from category.tenantId
+          'authorization': 'Bearer test-token'
+        }
+      });
+
+      const responseWithDifferentTenant = await GET(reqWithDifferentTenant, { params: { id: 'test-category-id' } });
+      const responseDataWithDifferentTenant = await responseWithDifferentTenant.json();
+
+      // Should return 404 when tenant doesn't match
+      expect(responseWithDifferentTenant.status).toBe(404);
+      expect(responseDataWithDifferentTenant.error).toBe('Category not found or does not belong to this tenant');
+    });
+  });
+});

--- a/tests/unit/api/admin/categories/tenant-validation.test.ts
+++ b/tests/unit/api/admin/categories/tenant-validation.test.ts
@@ -1,0 +1,382 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { redis, kv } from '@/lib/redis-client';
+import { Category } from '@/types';
+import { categoryKeys } from '@/lib/tenant/redis-keys';
+
+// Mock Redis client
+jest.mock('@/lib/redis-client', () => ({
+  redis: {
+    get: jest.fn(),
+    set: jest.fn(),
+    del: jest.fn(),
+    keys: jest.fn(),
+  },
+  kv: {
+    get: jest.fn(),
+    set: jest.fn(),
+    del: jest.fn(),
+    keys: jest.fn(),
+  }
+}));
+
+// Mock the middleware to pass through to the handler
+jest.mock('@/middleware/tenant-validation', () => ({
+  withTenantAccess: jest.fn().mockImplementation((req, handlerOrMiddleware) => {
+    // If handlerOrMiddleware is a function, call it directly
+    if (typeof handlerOrMiddleware === 'function') {
+      return handlerOrMiddleware(req);
+    }
+    // Otherwise, it's the result of another middleware, so call it with the request
+    return handlerOrMiddleware(req);
+  }),
+}));
+
+jest.mock('@/middleware/withPermission', () => ({
+  withPermission: jest.fn().mockImplementation((req, resourceType, permission, handler) => {
+    // Return a function that will be called by withTenantAccess
+    return (validatedReq) => handler(validatedReq);
+  }),
+  withResourcePermission: jest.fn().mockImplementation((req, resourceType, permission, handler) => {
+    // Return a function that will be called by withTenantAccess
+    return (validatedReq) => handler(validatedReq);
+  }),
+}));
+
+describe('Category API Tenant Validation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('GET /api/admin/categories/:id', () => {
+    it('should return 404 when category does not exist', async () => {
+      // Mock implementation to simulate category not found
+      (kv.get as jest.Mock).mockResolvedValue(null);
+
+      // Import the route handler
+      const { GET } = require('@/app/api/admin/categories/[id]/route');
+
+      // Create a test request
+      const req = new NextRequest('https://example.com/api/admin/categories/non-existent-id', {
+        headers: {
+          'x-tenant-id': 'test-tenant',
+          'authorization': 'Bearer test-token'
+        }
+      });
+
+      // Call the route handler with params
+      const response = await GET(req, { params: { id: 'non-existent-id' } });
+
+      // Parse the response
+      const responseData = await response.json();
+
+      // Verify the response status and message
+      expect(response.status).toBe(404);
+      expect(responseData.error).toBe('Category not found or does not belong to this tenant');
+    });
+
+    it('should return 404 when category belongs to a different tenant', async () => {
+      // Mock implementation to simulate category from different tenant
+      const mockCategory: Category = {
+        id: 'test-category-id',
+        siteId: 'test-site',
+        tenantId: 'different-tenant', // Different from the request tenant
+        name: 'Test Category',
+        slug: 'test-category',
+        metaDescription: 'Test category description',
+        order: 1,
+        createdAt: Date.now(),
+        updatedAt: Date.now()
+      };
+
+      (kv.get as jest.Mock).mockResolvedValue(mockCategory);
+
+      // Import the route handler
+      const { GET } = require('@/app/api/admin/categories/[id]/route');
+
+      // Create a test request with a different tenant
+      const req = new NextRequest('https://example.com/api/admin/categories/test-category-id', {
+        headers: {
+          'x-tenant-id': 'test-tenant', // Different from the category's tenant
+          'authorization': 'Bearer test-token'
+        }
+      });
+
+      // Call the route handler with params
+      const response = await GET(req, { params: { id: 'test-category-id' } });
+
+      // Parse the response
+      const responseData = await response.json();
+
+      // Verify the response status and message
+      expect(response.status).toBe(404);
+      expect(responseData.error).toBe('Category not found or does not belong to this tenant');
+    });
+
+    it('should return the category when it belongs to the correct tenant', async () => {
+      // Mock implementation to simulate category from the correct tenant
+      const mockCategory: Category = {
+        id: 'test-category-id',
+        siteId: 'test-site',
+        tenantId: 'test-tenant', // Same as the request tenant
+        name: 'Test Category',
+        slug: 'test-category',
+        metaDescription: 'Test category description',
+        order: 1,
+        createdAt: Date.now(),
+        updatedAt: Date.now()
+      };
+
+      (kv.get as jest.Mock).mockResolvedValue(mockCategory);
+
+      // Import the route handler
+      const { GET } = require('@/app/api/admin/categories/[id]/route');
+
+      // Create a test request with the matching tenant
+      const req = new NextRequest('https://example.com/api/admin/categories/test-category-id', {
+        headers: {
+          'x-tenant-id': 'test-tenant', // Same as the category's tenant
+          'authorization': 'Bearer test-token'
+        }
+      });
+
+      // Call the route handler with params
+      const response = await GET(req, { params: { id: 'test-category-id' } });
+
+      // Parse the response
+      const responseData = await response.json();
+
+      // Verify the response status and data
+      expect(response.status).toBe(200);
+      expect(responseData.category).toEqual(mockCategory);
+    });
+  });
+
+  describe('PUT /api/admin/categories/:id', () => {
+    it('should return 404 when category does not exist', async () => {
+      // Mock implementation to simulate category not found
+      (kv.get as jest.Mock).mockResolvedValue(null);
+
+      // Import the route handler
+      const { PUT } = require('@/app/api/admin/categories/[id]/route');
+
+      // Create a test request
+      const req = new NextRequest('https://example.com/api/admin/categories/non-existent-id', {
+        method: 'PUT',
+        headers: {
+          'x-tenant-id': 'test-tenant',
+          'authorization': 'Bearer test-token',
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({ name: 'Updated Category' })
+      });
+
+      // Call the route handler with params
+      const response = await PUT(req, { params: { id: 'non-existent-id' } });
+
+      // Parse the response
+      const responseData = await response.json();
+
+      // Verify the response status and message
+      expect(response.status).toBe(404);
+      expect(responseData.error).toBe('Category not found or does not belong to this tenant');
+    });
+
+    it('should return 404 when category belongs to a different tenant', async () => {
+      // Mock implementation to simulate category from different tenant
+      const mockCategory: Category = {
+        id: 'test-category-id',
+        siteId: 'test-site',
+        tenantId: 'different-tenant', // Different from the request tenant
+        name: 'Test Category',
+        slug: 'test-category',
+        metaDescription: 'Test category description',
+        order: 1,
+        createdAt: Date.now(),
+        updatedAt: Date.now()
+      };
+
+      (kv.get as jest.Mock).mockResolvedValue(mockCategory);
+
+      // Import the route handler
+      const { PUT } = require('@/app/api/admin/categories/[id]/route');
+
+      // Create a test request with a different tenant
+      const req = new NextRequest('https://example.com/api/admin/categories/test-category-id', {
+        method: 'PUT',
+        headers: {
+          'x-tenant-id': 'test-tenant', // Different from the category's tenant
+          'authorization': 'Bearer test-token',
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({ name: 'Updated Category' })
+      });
+
+      // Call the route handler with params
+      const response = await PUT(req, { params: { id: 'test-category-id' } });
+
+      // Parse the response
+      const responseData = await response.json();
+
+      // Verify the response status and message
+      expect(response.status).toBe(404);
+      expect(responseData.error).toBe('Category not found or does not belong to this tenant');
+    });
+
+    it('should update the category when it belongs to the correct tenant', async () => {
+      // Mock implementation to simulate category from the correct tenant
+      const mockCategory: Category = {
+        id: 'test-category-id',
+        siteId: 'test-site',
+        tenantId: 'test-tenant', // Same as the request tenant
+        name: 'Test Category',
+        slug: 'test-category',
+        metaDescription: 'Test category description',
+        order: 1,
+        createdAt: Date.now(),
+        updatedAt: Date.now()
+      };
+
+      (kv.get as jest.Mock).mockResolvedValue(mockCategory);
+      (kv.set as jest.Mock).mockResolvedValue(undefined);
+
+      // Import the route handler
+      const { PUT } = require('@/app/api/admin/categories/[id]/route');
+
+      const updateData = { name: 'Updated Category' };
+
+      // Create a test request with the matching tenant
+      const req = new NextRequest('https://example.com/api/admin/categories/test-category-id', {
+        method: 'PUT',
+        headers: {
+          'x-tenant-id': 'test-tenant', // Same as the category's tenant
+          'authorization': 'Bearer test-token',
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify(updateData)
+      });
+
+      // Call the route handler with params
+      const response = await PUT(req, { params: { id: 'test-category-id' } });
+
+      // Parse the response
+      const responseData = await response.json();
+
+      // Verify the response status and data
+      expect(response.status).toBe(200);
+      expect(responseData.category).toMatchObject({
+        ...mockCategory,
+        ...updateData,
+        tenantId: 'test-tenant' // Ensure tenant ID remains unchanged
+      });
+    });
+  });
+
+  describe('DELETE /api/admin/categories/:id', () => {
+    it('should return 404 when category does not exist', async () => {
+      // Mock implementation to simulate category not found
+      (kv.get as jest.Mock).mockResolvedValue(null);
+
+      // Import the route handler
+      const { DELETE } = require('@/app/api/admin/categories/[id]/route');
+
+      // Create a test request
+      const req = new NextRequest('https://example.com/api/admin/categories/non-existent-id', {
+        method: 'DELETE',
+        headers: {
+          'x-tenant-id': 'test-tenant',
+          'authorization': 'Bearer test-token'
+        }
+      });
+
+      // Call the route handler with params
+      const response = await DELETE(req, { params: { id: 'non-existent-id' } });
+
+      // Parse the response
+      const responseData = await response.json();
+
+      // Verify the response status and message
+      expect(response.status).toBe(404);
+      expect(responseData.error).toBe('Category not found or does not belong to this tenant');
+    });
+
+    it('should return 404 when category belongs to a different tenant', async () => {
+      // Mock implementation to simulate category from different tenant
+      const mockCategory: Category = {
+        id: 'test-category-id',
+        siteId: 'test-site',
+        tenantId: 'different-tenant', // Different from the request tenant
+        name: 'Test Category',
+        slug: 'test-category',
+        metaDescription: 'Test category description',
+        order: 1,
+        createdAt: Date.now(),
+        updatedAt: Date.now()
+      };
+
+      (kv.get as jest.Mock).mockResolvedValue(mockCategory);
+
+      // Import the route handler
+      const { DELETE } = require('@/app/api/admin/categories/[id]/route');
+
+      // Create a test request with a different tenant
+      const req = new NextRequest('https://example.com/api/admin/categories/test-category-id', {
+        method: 'DELETE',
+        headers: {
+          'x-tenant-id': 'test-tenant', // Different from the category's tenant
+          'authorization': 'Bearer test-token'
+        }
+      });
+
+      // Call the route handler with params
+      const response = await DELETE(req, { params: { id: 'test-category-id' } });
+
+      // Parse the response
+      const responseData = await response.json();
+
+      // Verify the response status and message
+      expect(response.status).toBe(404);
+      expect(responseData.error).toBe('Category not found or does not belong to this tenant');
+    });
+
+    it('should delete the category when it belongs to the correct tenant', async () => {
+      // Mock implementation to simulate category from the correct tenant
+      const mockCategory: Category = {
+        id: 'test-category-id',
+        siteId: 'test-site',
+        tenantId: 'test-tenant', // Same as the request tenant
+        name: 'Test Category',
+        slug: 'test-category',
+        metaDescription: 'Test category description',
+        order: 1,
+        createdAt: Date.now(),
+        updatedAt: Date.now()
+      };
+
+      (kv.get as jest.Mock).mockResolvedValue(mockCategory);
+      (kv.del as jest.Mock).mockResolvedValue(undefined);
+
+      // Import the route handler
+      const { DELETE } = require('@/app/api/admin/categories/[id]/route');
+
+      // Create a test request with the matching tenant
+      const req = new NextRequest('https://example.com/api/admin/categories/test-category-id', {
+        method: 'DELETE',
+        headers: {
+          'x-tenant-id': 'test-tenant', // Same as the category's tenant
+          'authorization': 'Bearer test-token'
+        }
+      });
+
+      // Call the route handler with params
+      const response = await DELETE(req, { params: { id: 'test-category-id' } });
+
+      // Parse the response
+      const responseData = await response.json();
+
+      // Verify the response status and message
+      expect(response.status).toBe(200);
+      expect(responseData.success).toBe(true);
+      expect(responseData.message).toContain('deleted successfully');
+    });
+  });
+});


### PR DESCRIPTION
## Description

This PR adds comprehensive tests for tenant validation in the category API endpoints. These tests ensure that categories can only be accessed by the tenant they belong to, which is an important security feature for a multi-tenant application.

## Changes

- Added `tenant-validation.test.ts` - Comprehensive tests for tenant validation across all category API endpoints
- Added `tenant-validation-simple.test.ts` - Simplified test focusing on the GET endpoint

## Testing

These tests can be run with:

```bash
npm test -- tests/unit/api/admin/categories/tenant-validation.test.ts
```

or

```bash
npm test -- tests/unit/api/admin/categories/tenant-validation-simple.test.ts
```

Using our new consolidated test runner.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Introduced new tests ensuring that category management endpoints correctly handle requests based on tenant ownership.
	- Verified that fetching, updating, and deleting categories return appropriate success or error responses depending on tenant matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->