### PR TITLE
Fix: Add authentication to sites API endpoints

### DIFF
--- a/checkpoint.md
+++ b/checkpoint.md
@@ -58,11 +58,22 @@ I've successfully added proper authentication to the sites API endpoints:
 
 These changes ensure that only authenticated users with the proper permissions can access or create site data, which is critical for maintaining proper multi-tenant security in the application.
 
-## Next Steps
+## Completed Work
 
-1. Commit the changes
-2. Push the branch
-3. Create a PR for review
+1. Created branch `fix/sites-api-authentication`
+2. Added security middleware to both API endpoints:
+   - Wrapped the GET handler with `withPermission` requiring 'site' resource type and 'read' permission
+   - Wrapped the POST handler with `withPermission` requiring 'site' resource type and 'create' permission
+3. Added proper JSDoc comments to the functions to document security requirements
+4. Updated request parameter to use the validated request from the middleware
+5. Committed the changes and pushed the branch
+6. Created pull request #109 for review
+
+This completes the fix for the security issue in the sites API endpoints. The PR has been created and is ready for review.
+
+## Summary
+
+This fix addresses an important security vulnerability by ensuring that only authenticated users with proper permissions can access or modify site data. This is critical for maintaining proper multi-tenant isolation in the application. By using the existing `withPermission` middleware pattern, the implementation is consistent with the rest of the codebase and follows established security practices.
 
 ## Current Status
 - ✅ PR #99 has been successfully merged to main

--- a/src/app/api/sites/route.ts
+++ b/src/app/api/sites/route.ts
@@ -2,94 +2,123 @@ import { NextRequest, NextResponse } from 'next/server';
 import { kv, redis } from '@/lib/redis-client';
 import { SiteConfig } from '@/types';
 import { withRedis } from '@/middleware/withRedis';
+import { withPermission } from '@/middleware/tenant-validation';
+import { ResourceType, Permission } from '@/types/permissions';
 
+/**
+ * GET handler for retrieving all sites
+ * 
+ * @param request The incoming request object
+ * @returns JSON response with array of site configurations
+ * 
+ * @security Requires 'site:read' permission
+ */
 export const GET = withRedis(async (request: NextRequest) => {
-  // TODO: Add authentication
-  
-  const sites = await kv.keys('site:slug:*');
-  const siteData = await Promise.all(
-    sites.map(async (key) => await kv.get<SiteConfig>(key))
+  return withPermission(
+    request,
+    'site' as ResourceType,
+    'read' as Permission,
+    async (validatedReq: NextRequest) => {
+      const sites = await kv.keys('site:slug:*');
+      const siteData = await Promise.all(
+        sites.map(async (key) => await kv.get<SiteConfig>(key))
+      );
+      
+      return NextResponse.json(siteData);
+    }
   );
-  
-  return NextResponse.json(siteData);
 });
 
+/**
+ * POST handler for creating a new site
+ * 
+ * @param request The incoming request object
+ * @returns JSON response with the created site or error message
+ * 
+ * @security Requires 'site:create' permission
+ */
 export const POST = withRedis(async (request: NextRequest) => {
-  // TODO: Add authentication
+  return withPermission(
+    request,
+    'site' as ResourceType,
+    'create' as Permission,
+    async (validatedReq: NextRequest) => {
   
-  try {
-    const data = await request.json();
-    
-    // Validate required fields
-    if (!data.name || !data.slug || !data.primaryKeyword || !data.metaDescription || !data.headerText) {
-      return NextResponse.json(
-        { error: 'Missing required fields' },
-        { status: 400 }
-      );
-    }
-    
-    // Check if site slug already exists
-    const existingSite = await kv.get(`site:slug:${data.slug}`);
-    if (existingSite) {
-      return NextResponse.json(
-        { error: 'Site slug already exists' },
-        { status: 409 }
-      );
-    }
-    
-    // Create new site
-    const timestamp = Date.now();
-    const site: SiteConfig = {
-      id: `site_${timestamp}`,
-      name: data.name,
-      slug: data.slug,
-      domain: data.domain,
-      primaryKeyword: data.primaryKeyword,
-      metaDescription: data.metaDescription,
-      logoUrl: data.logoUrl,
-      headerText: data.headerText,
-      defaultLinkAttributes: data.defaultLinkAttributes || 'dofollow',
-      createdAt: timestamp,
-      updatedAt: timestamp,
-    };
-    
-    // Use a Redis transaction for atomicity
-    const multi = redis.multi();
-    
-    multi.set(`site:id:${site.id}`, JSON.stringify(site));
-    multi.set(`site:slug:${site.slug}`, JSON.stringify(site));
-    
-    if (site.domain) {
-      multi.set(`site:domain:${site.domain}`, JSON.stringify(site));
-    }
-    
-    try {
-      // Execute all commands as a transaction
-      const results = await multi.exec();
-      
-      // Check for errors in the transaction
-      const errors = results.filter(([err]) => err !== null);
-      if (errors.length > 0) {
-        console.error('Transaction errors:', errors);
+      try {
+        const data = await validatedReq.json();
+        
+        // Validate required fields
+        if (!data.name || !data.slug || !data.primaryKeyword || !data.metaDescription || !data.headerText) {
+          return NextResponse.json(
+            { error: 'Missing required fields' },
+            { status: 400 }
+          );
+        }
+        
+        // Check if site slug already exists
+        const existingSite = await kv.get(`site:slug:${data.slug}`);
+        if (existingSite) {
+          return NextResponse.json(
+            { error: 'Site slug already exists' },
+            { status: 409 }
+          );
+        }
+        
+        // Create new site
+        const timestamp = Date.now();
+        const site: SiteConfig = {
+          id: `site_${timestamp}`,
+          name: data.name,
+          slug: data.slug,
+          domain: data.domain,
+          primaryKeyword: data.primaryKeyword,
+          metaDescription: data.metaDescription,
+          logoUrl: data.logoUrl,
+          headerText: data.headerText,
+          defaultLinkAttributes: data.defaultLinkAttributes || 'dofollow',
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        };
+        
+        // Use a Redis transaction for atomicity
+        const multi = redis.multi();
+        
+        multi.set(`site:id:${site.id}`, JSON.stringify(site));
+        multi.set(`site:slug:${site.slug}`, JSON.stringify(site));
+        
+        if (site.domain) {
+          multi.set(`site:domain:${site.domain}`, JSON.stringify(site));
+        }
+        
+        try {
+          // Execute all commands as a transaction
+          const results = await multi.exec();
+          
+          // Check for errors in the transaction
+          const errors = results.filter(([err]) => err !== null);
+          if (errors.length > 0) {
+            console.error('Transaction errors:', errors);
+            return NextResponse.json(
+              { error: 'Failed to save site data' },
+              { status: 500 }
+            );
+          }
+          
+          return NextResponse.json(site, { status: 201 });
+        } catch (error) {
+          console.error('Error executing Redis transaction:', error);
+          return NextResponse.json(
+            { error: 'Failed to save site data' },
+            { status: 500 }
+          );
+        }
+      } catch (error) {
+        console.error('Error creating site:', error);
         return NextResponse.json(
-          { error: 'Failed to save site data' },
+          { error: 'Internal server error' },
           { status: 500 }
         );
       }
-      
-      return NextResponse.json(site, { status: 201 });
-    } catch (error) {
-      console.error('Error executing Redis transaction:', error);
-      return NextResponse.json(
-        { error: 'Failed to save site data' },
-        { status: 500 }
-      );
     }
-  } catch (error) {
-    console.error('Error creating site:', error);
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    );
-  }
+  );
 });


### PR DESCRIPTION
This PR adds proper authentication to the sites API endpoints.\n\nChanges:\n\n- Added withPermission middleware to both GET and POST endpoints\n- Require 'site:read' permission for GET operations\n- Require 'site:create' permission for POST operations\n- Added JSDoc comments for better security documentation\n\nThese changes help maintain proper multi-tenant security in the application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced security for site data operations by enforcing strict permission validations. These updates ensure that only authorized users can access or modify site information.
  
- **Documentation**
  - Updated guidance to clearly explain the new security requirements, providing users with better insight into the updated authentication processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->