### PR TITLE
Fix ListingTableHeader tests

### DIFF
--- a/tests/admin/listings/ListingTableHeader.test.tsx
+++ b/tests/admin/listings/ListingTableHeader.test.tsx
@@ -37,86 +37,90 @@ describe('ListingTableHeader Component', () => {
     categories: mockCategories,
     sites: mockSites
   };
-  
+
   it('renders the header with correct listing count', () => {
     render(<ListingTableHeader {...defaultProps} />);
-    
+
     expect(screen.getByText('Listings (5)')).toBeInTheDocument();
   });
-  
+
   it('renders the add new listing button with correct href', () => {
     render(<ListingTableHeader {...defaultProps} />);
-    
+
     const addButton = screen.getByText('Add New Listing');
     expect(addButton).toBeInTheDocument();
     expect(addButton.closest('a')).toHaveAttribute('href', '/admin/listings/new');
   });
-  
+
   it('uses site-specific URL when siteSlug is provided', () => {
     render(<ListingTableHeader {...defaultProps} siteSlug="test-site" />);
-    
+
     const addButton = screen.getByText('Add New Listing');
     expect(addButton.closest('a')).toHaveAttribute('href', '/admin/test-site/listings/new');
   });
-  
+
   it('calls setSearchTerm when search input changes', () => {
     render(<ListingTableHeader {...defaultProps} />);
-    
+
     const searchInput = screen.getByPlaceholderText('Search listings...');
     fireEvent.change(searchInput, { target: { value: 'test search' } });
-    
+
     expect(defaultProps.setSearchTerm).toHaveBeenCalledWith('test search');
   });
-  
+
   it('renders the clear search button when searchTerm has a value', () => {
     const props = { ...defaultProps, searchTerm: 'test search' };
     render(<ListingTableHeader {...props} />);
-    
+
     const clearButton = screen.getByRole('button', { name: 'Clear search' });
     expect(clearButton).toBeInTheDocument();
-    
+
     fireEvent.click(clearButton);
     expect(props.setSearchTerm).toHaveBeenCalledWith('');
   });
-  
+
   it('renders category filter dropdown with correct options', () => {
     render(<ListingTableHeader {...defaultProps} />);
-    
+
     const categorySelect = screen.getByRole('combobox', { name: 'Filter by category' });
     expect(categorySelect).toBeInTheDocument();
-    
-    const options = screen.getAllByRole('option');
-    expect(options.length).toBe(mockCategories.length + 1); // +1 for the "All Categories" option
-    expect(options[0]).toHaveTextContent('All Categories');
-    expect(options[1]).toHaveTextContent('Category 1');
-    expect(options[2]).toHaveTextContent('Category 2');
+
+    // Get only the options within the category filter dropdown
+    const categoryOptions = Array.from(categorySelect.querySelectorAll('option'));
+    expect(categoryOptions.length).toBe(mockCategories.length + 1); // +1 for the "All Categories" option
+    expect(categoryOptions[0]).toHaveTextContent('All Categories');
+    expect(categoryOptions[1]).toHaveTextContent('Category 1');
+    expect(categoryOptions[2]).toHaveTextContent('Category 2');
   });
-  
+
   it('calls setCategoryFilter when category selection changes', () => {
     render(<ListingTableHeader {...defaultProps} />);
-    
+
     const categorySelect = screen.getByRole('combobox', { name: 'Filter by category' });
     fireEvent.change(categorySelect, { target: { value: 'category_1' } });
-    
+
     expect(defaultProps.setCategoryFilter).toHaveBeenCalledWith('category_1');
   });
-  
+
   it('renders site filter dropdown only in multi-site mode', () => {
     // Without siteSlug (multi-site mode)
-    render(<ListingTableHeader {...defaultProps} />);
-    
+    const { unmount } = render(<ListingTableHeader {...defaultProps} />);
+
     const siteSelect = screen.getByRole('combobox', { name: 'Filter by site' });
     expect(siteSelect).toBeInTheDocument();
-    
+
+    // Clean up the first render to avoid conflicts
+    unmount();
+
     // With siteSlug (single-site mode)
     render(<ListingTableHeader {...defaultProps} siteSlug="test-site" />);
-    
+
     expect(screen.queryByRole('combobox', { name: 'Filter by site' })).not.toBeInTheDocument();
   });
-  
+
   it('uses responsive layout for filter controls', () => {
     render(<ListingTableHeader {...defaultProps} />);
-    
+
     const filterContainer = screen.getByPlaceholderText('Search listings...').closest('div');
     expect(filterContainer?.parentElement).toHaveClass('flex-col sm:flex-row');
   });


### PR DESCRIPTION
This PR fixes the ListingTableHeader tests to properly handle multiple select elements.

## Changes
- Updated the category filter test to only check options within the category select element
- Fixed the site filter test by properly unmounting the first render before testing the second case

## Testing
All tests now pass successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Enhanced automated tests for filtering functionalities to ensure more precise validation.
  - Added cleanup steps during testing to prevent conflicts between sequential validations.
  - Made minor style improvements to improve readability within the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->