### PR TITLE
Fix AdminSidebar test by properly mocking usePathname

### DIFF
--- a/tests/admin/layout/AdminSidebar.test.tsx
+++ b/tests/admin/layout/AdminSidebar.test.tsx
@@ -3,10 +3,9 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { AdminSidebar } from '@/components/admin/layout';
 
 // Mock next/navigation
-const mockUsePathname = jest.fn().mockReturnValue('/admin/listings');
 jest.mock('next/navigation', () => ({
   __esModule: true,
-  usePathname: () => mockUsePathname()
+  usePathname: () => '/admin/listings'
 }));
 
 // Mock next/link


### PR DESCRIPTION
This PR fixes the AdminSidebar test by properly mocking the usePathname hook from Next.js navigation.

## Changes
- Updated the mock implementation to directly return the path string instead of using a function that returns a function
- Removed the unnecessary mockUsePathname variable

## Testing
- Verified that all tests in AdminSidebar.test.tsx now pass