### PR TITLE
Fix Breadcrumbs test by mocking ChevronRightIcon component

### DIFF
--- a/tests/admin/layout/Breadcrumbs.test.tsx
+++ b/tests/admin/layout/Breadcrumbs.test.tsx
@@ -18,6 +18,13 @@ jest.mock('next/link', () => {
   };
 });
 
+// Mock the ChevronRightIcon component
+jest.mock('@/components/admin/layout/icons', () => ({
+  ChevronRightIcon: ({ className }: { className: string }) => (
+    <svg className={className} data-testid="chevron-right-icon" />
+  ),
+}));
+
 describe('Breadcrumbs Component', () => {
   it('renders nothing when on admin root path', () => {
     const { container } = render(<Breadcrumbs pathname="/admin" />);


### PR DESCRIPTION
This PR fixes the Breadcrumbs test by properly mocking the ChevronRightIcon component.

## Changes
- Added a mock for the ChevronRightIcon component to ensure it renders properly in tests
- Fixed the test that checks for the aria-current attribute

## Testing
- Verified that all tests in Breadcrumbs.test.tsx now pass