### PR TITLE
Fix AdminHeader test by properly mocking icons

### DIFF
--- a/tests/admin/layout/AdminHeader.test.tsx
+++ b/tests/admin/layout/AdminHeader.test.tsx
@@ -20,6 +20,14 @@ jest.mock('next/link', () => {
   };
 });
 
+// Mock the icons
+jest.mock('@/components/admin/layout/icons', () => ({
+  __esModule: true,
+  MenuIcon: ({ className }: { className?: string }) => <svg className={className} data-testid="menu-icon" />,
+  BellIcon: ({ className }: { className?: string }) => <svg className={className} data-testid="bell-icon" />,
+  UserIcon: ({ className }: { className?: string }) => <svg className={className} data-testid="user-icon" />
+}));
+
 describe('AdminHeader Component', () => {
   const mockToggleSidebar = jest.fn();
 


### PR DESCRIPTION
This PR fixes the AdminHeader test by properly mocking the icons used in the AdminHeader component.

## Changes
- Added mocks for MenuIcon, BellIcon, and UserIcon components
- Added the __esModule: true flag to the mock to ensure proper ES module handling

## Testing
- Verified that all tests in AdminHeader.test.tsx now pass