### PR TITLE
Fix DeleteConfirmationModal tests

### DIFF
--- a/tests/admin/sites/table/DeleteConfirmationModal.test.tsx
+++ b/tests/admin/sites/table/DeleteConfirmationModal.test.tsx
@@ -6,67 +6,66 @@ describe('DeleteConfirmationModal Component - Basic Rendering', () => {
   it('renders the modal when isOpen is true', () => {
     const mockOnConfirm = jest.fn();
     const mockOnCancel = jest.fn();
-    
+
     render(
-      <DeleteConfirmationModal 
+      <DeleteConfirmationModal
         isOpen={true}
-        siteId="site-123"
         siteName="Test Site"
+        isLoading={false}
         onConfirm={mockOnConfirm}
         onCancel={mockOnCancel}
       />
     );
-    
+
     // Check if modal content is rendered
-    expect(screen.getByTestId('delete-modal')).toBeInTheDocument();
-    expect(screen.getByTestId('delete-modal-title')).toBeInTheDocument();
-    expect(screen.getByTestId('delete-modal-content')).toBeInTheDocument();
-    
+    expect(screen.getByTestId('delete-confirmation-modal')).toBeInTheDocument();
+    expect(screen.getByTestId('modal-title')).toBeInTheDocument();
+
     // Check if the site name is displayed
-    expect(screen.getByTestId('delete-modal-content')).toHaveTextContent('Test Site');
-    
+    expect(screen.getByText(/Test Site/)).toBeInTheDocument();
+
     // Check if action buttons are rendered
-    expect(screen.getByTestId('delete-modal-cancel')).toBeInTheDocument();
-    expect(screen.getByTestId('delete-modal-confirm')).toBeInTheDocument();
+    expect(screen.getByTestId('cancel-delete-button')).toBeInTheDocument();
+    expect(screen.getByTestId('confirm-delete-button')).toBeInTheDocument();
   });
 
   it('does not render the modal when isOpen is false', () => {
     const mockOnConfirm = jest.fn();
     const mockOnCancel = jest.fn();
-    
+
     render(
-      <DeleteConfirmationModal 
+      <DeleteConfirmationModal
         isOpen={false}
-        siteId="site-123"
         siteName="Test Site"
+        isLoading={false}
         onConfirm={mockOnConfirm}
         onCancel={mockOnCancel}
       />
     );
-    
+
     // Modal should not be rendered
-    expect(screen.queryByTestId('delete-modal')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('delete-confirmation-modal')).not.toBeInTheDocument();
   });
 
   it('has appropriate warning styling', () => {
     const mockOnConfirm = jest.fn();
     const mockOnCancel = jest.fn();
-    
+
     render(
-      <DeleteConfirmationModal 
+      <DeleteConfirmationModal
         isOpen={true}
-        siteId="site-123"
         siteName="Test Site"
+        isLoading={false}
         onConfirm={mockOnConfirm}
         onCancel={mockOnCancel}
       />
     );
-    
+
     // Delete button should have warning/danger styling
-    const deleteButton = screen.getByTestId('delete-modal-confirm');
-    expect(deleteButton).toHaveClass('danger', { exact: false }); // The actual class name may vary
-    
+    const deleteButton = screen.getByTestId('confirm-delete-button');
+    expect(deleteButton).toHaveClass('bg-red-600', { exact: false }); // Check for red background class
+
     // Delete button should have descriptive text
-    expect(deleteButton).toHaveTextContent(/delete|remove/i);
+    expect(deleteButton).toHaveTextContent(/delete/i);
   });
 });


### PR DESCRIPTION
This PR fixes the DeleteConfirmationModal tests.

## Changes
- Updated tests to match the current component structure
- Fixed prop types in the tests to match the component's expected props
- Updated test assertions to use the correct data-testid attributes
- Fixed class name assertions to match the actual component styling

## Testing
All tests now pass successfully.