### PR TITLE
Fix SiteMobileCard tests

### DIFF
--- a/tests/admin/sites/table/SiteMobileCard.test.tsx
+++ b/tests/admin/sites/table/SiteMobileCard.test.tsx
@@ -2,6 +2,13 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { SiteMobileCard } from '@/components/admin/sites/table/SiteMobileCard';
 
+// Mock next/link
+jest.mock('next/link', () => {
+  return ({ children, href }: { children: React.ReactNode, href: string }) => {
+    return <a href={href}>{children}</a>;
+  };
+});
+
 describe('SiteMobileCard Component - Basic Rendering', () => {
   // Mock site data
   const mockSite = {
@@ -9,68 +16,65 @@ describe('SiteMobileCard Component - Basic Rendering', () => {
     name: 'Test Site',
     slug: 'test-site',
     domains: ['example.com'],
-    lastModified: '2025-03-30T14:30:00Z',
-    status: 'active'
+    createdAt: '2025-03-30T14:30:00Z',
+    updatedAt: '2025-03-30T14:30:00Z'
   };
-  
+
   // Mock functions
-  const mockOnEdit = jest.fn();
   const mockOnDelete = jest.fn();
-  
+
   it('renders site basic information correctly', () => {
     render(
-      <SiteMobileCard 
-        site={mockSite} 
-        onEdit={mockOnEdit} 
-        onDelete={mockOnDelete} 
+      <SiteMobileCard
+        site={mockSite}
+        onDelete={mockOnDelete}
       />
     );
-    
+
     // Check if site name and slug are displayed
-    expect(screen.getByTestId('mobile-site-name')).toHaveTextContent('Test Site');
-    expect(screen.getByTestId('mobile-site-slug')).toHaveTextContent('test-site');
+    expect(screen.getByTestId(`site-mobile-name-${mockSite.id}`)).toHaveTextContent('Test Site');
+    expect(screen.getByTestId(`site-mobile-slug-${mockSite.id}`)).toHaveTextContent('test-site');
   });
 
   it('displays domain information', () => {
     render(
-      <SiteMobileCard 
-        site={mockSite} 
-        onEdit={mockOnEdit} 
-        onDelete={mockOnDelete} 
+      <SiteMobileCard
+        site={mockSite}
+        onDelete={mockOnDelete}
       />
     );
-    
+
     // Check if domain is displayed
-    expect(screen.getByTestId('mobile-site-domains')).toHaveTextContent('example.com');
+    expect(screen.getByTestId(`site-mobile-domain-0-${mockSite.id}`)).toHaveTextContent('example.com');
   });
 
-  it('shows status indicator', () => {
+  it('shows created date', () => {
     render(
-      <SiteMobileCard 
-        site={mockSite} 
-        onEdit={mockOnEdit} 
-        onDelete={mockOnDelete} 
+      <SiteMobileCard
+        site={mockSite}
+        onDelete={mockOnDelete}
       />
     );
-    
-    // Check if status is displayed
-    expect(screen.getByTestId('mobile-site-status')).toHaveTextContent('active');
-    
-    // Active status should have appropriate styling
-    expect(screen.getByTestId('mobile-site-status')).toHaveClass('active', { exact: false });
+
+    // Check if created date is displayed
+    expect(screen.getByTestId(`site-mobile-created-${mockSite.id}`)).toBeInTheDocument();
+    // Since we're using a date formatter, we can't check the exact text content
   });
 
   it('renders action buttons', () => {
     render(
-      <SiteMobileCard 
-        site={mockSite} 
-        onEdit={mockOnEdit} 
-        onDelete={mockOnDelete} 
+      <SiteMobileCard
+        site={mockSite}
+        onDelete={mockOnDelete}
       />
     );
-    
+
     // Check if action buttons are rendered
-    expect(screen.getByTestId('mobile-edit-button')).toBeInTheDocument();
-    expect(screen.getByTestId('mobile-delete-button')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /edit site/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /delete site/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /view site/i })).toBeInTheDocument();
+
+    // Check delete button has the correct data-testid
+    expect(screen.getByTestId(`mobile-delete-site-${mockSite.id}`)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
This PR fixes the SiteMobileCard tests.

## Changes
- Added Next.js Link component mock
- Updated tests to match the current component structure
- Fixed prop types in the tests to match the component's expected props
- Updated test assertions to use the correct data-testid attributes
- Added tests for the created date display

## Testing
All tests now pass successfully.