### PR TITLE
Fix categories API test

### DIFF
--- a/tests/api/categories/get.test.ts
+++ b/tests/api/categories/get.test.ts
@@ -32,24 +32,24 @@ describe('Categories API - GET', () => {
     // Mock the Redis client to return null for site
     const { kv } = require('../../../src/lib/redis-client');
     (kv.get as jest.Mock).mockResolvedValue(null);
-    
+
     // Create request
     const request = new NextRequest('http://localhost:3000/api/sites/non-existent/categories');
-    
+
     // Execute the route handler
     const response = await GET(request, { params: { siteSlug: 'non-existent' } });
-    
+
     // Parse the response
     const data = await response.json();
-    
+
     // Verify the response
     expect(response.status).toBe(404);
     expect(data).toEqual({
       error: 'Site not found',
     });
-    
+
     // Verify the Redis client was called correctly
-    expect(kv.get).toHaveBeenCalledWith('site:slug:non-existent');
+    expect(kv.get).toHaveBeenCalledWith('test:site:slug:non-existent');
   });
 
   it('should return categories for a valid site', async () => {
@@ -65,7 +65,7 @@ describe('Categories API - GET', () => {
       createdAt: 1000,
       updatedAt: 1000,
     };
-    
+
     // Mock categories
     const mockCategories = [
       {
@@ -89,42 +89,42 @@ describe('Categories API - GET', () => {
         updatedAt: 2000,
       },
     ];
-    
+
     // Mock the Redis client
     const { kv } = require('../../../src/lib/redis-client');
     (kv.get as jest.Mock).mockImplementation((key) => {
-      if (key === 'site:slug:test-site') {
+      if (key === 'test:site:slug:test-site') {
         return Promise.resolve(mockSite);
       }
-      if (key === 'category:site:site1:test-category-1') {
+      if (key === 'test:category:site:site1:test-category-1') {
         return Promise.resolve(mockCategories[0]);
       }
-      if (key === 'category:site:site1:test-category-2') {
+      if (key === 'test:category:site:site1:test-category-2') {
         return Promise.resolve(mockCategories[1]);
       }
       return Promise.resolve(null);
     });
     (kv.keys as jest.Mock).mockResolvedValue([
-      'category:site:site1:test-category-1',
-      'category:site:site1:test-category-2',
+      'test:category:site:site1:test-category-1',
+      'test:category:site:site1:test-category-2',
     ]);
-    
+
     // Create request
     const request = new NextRequest('http://localhost:3000/api/sites/test-site/categories');
-    
+
     // Execute the route handler
     const response = await GET(request, { params: { siteSlug: 'test-site' } });
-    
+
     // Parse the response
     const data = await response.json();
-    
+
     // Verify the response
     expect(response.status).toBe(200);
     expect(data).toEqual(mockCategories);
-    
+
     // Verify the Redis client was called correctly
-    expect(kv.get).toHaveBeenCalledWith('site:slug:test-site');
-    expect(kv.keys).toHaveBeenCalledWith('category:site:site1:*');
+    expect(kv.get).toHaveBeenCalledWith('test:site:slug:test-site');
+    expect(kv.keys).toHaveBeenCalledWith('test:category:site:site1:*');
   });
 
   it('should handle Redis keys error gracefully', async () => {
@@ -140,35 +140,35 @@ describe('Categories API - GET', () => {
       createdAt: 1000,
       updatedAt: 1000,
     };
-    
+
     // Mock the Redis client
     const { kv } = require('../../../src/lib/redis-client');
     (kv.get as jest.Mock).mockImplementation((key) => {
-      if (key === 'site:slug:test-site') {
+      if (key === 'test:site:slug:test-site') {
         return Promise.resolve(mockSite);
       }
       return Promise.resolve(null);
     });
     (kv.keys as jest.Mock).mockRejectedValue(new Error('Redis error'));
-    
+
     // Spy on console.error
     jest.spyOn(console, 'error').mockImplementation(() => {});
-    
+
     // Create request
     const request = new NextRequest('http://localhost:3000/api/sites/test-site/categories');
-    
+
     // Execute the route handler
     const response = await GET(request, { params: { siteSlug: 'test-site' } });
-    
+
     // Parse the response
     const data = await response.json();
-    
+
     // Verify the response
     expect(response.status).toBe(500);
     expect(data).toEqual({
       error: 'Failed to fetch categories',
     });
-    
+
     // Verify error was logged
     expect(console.error).toHaveBeenCalledWith(
       'Error fetching categories:',
@@ -189,7 +189,7 @@ describe('Categories API - GET', () => {
       createdAt: 1000,
       updatedAt: 1000,
     };
-    
+
     // Mock category
     const mockCategory = {
       id: 'cat1',
@@ -201,43 +201,43 @@ describe('Categories API - GET', () => {
       createdAt: 1000,
       updatedAt: 1000,
     };
-    
+
     // Mock the Redis client
     const { kv } = require('../../../src/lib/redis-client');
     (kv.get as jest.Mock).mockImplementation((key) => {
-      if (key === 'site:slug:test-site') {
+      if (key === 'test:site:slug:test-site') {
         return Promise.resolve(mockSite);
       }
-      if (key === 'category:site:site1:test-category-1') {
+      if (key === 'test:category:site:site1:test-category-1') {
         return Promise.resolve(mockCategory);
       }
-      if (key === 'category:site:site1:test-category-2') {
+      if (key === 'test:category:site:site1:test-category-2') {
         // This will trigger the error handler in the loop
         return Promise.reject(new Error('Failed to fetch category'));
       }
       return Promise.resolve(null);
     });
     (kv.keys as jest.Mock).mockResolvedValue([
-      'category:site:site1:test-category-1',
-      'category:site:site1:test-category-2',
+      'test:category:site:site1:test-category-1',
+      'test:category:site:site1:test-category-2',
     ]);
-    
+
     // Spy on console.error
     jest.spyOn(console, 'error').mockImplementation(() => {});
-    
+
     // Create request
     const request = new NextRequest('http://localhost:3000/api/sites/test-site/categories');
-    
+
     // Execute the route handler
     const response = await GET(request, { params: { siteSlug: 'test-site' } });
-    
+
     // Parse the response
     const data = await response.json();
-    
+
     // Verify the response - should still get the successful category
     expect(response.status).toBe(200);
     expect(data).toEqual([mockCategory]);
-    
+
     // Verify error was logged
     expect(console.error).toHaveBeenCalledWith(
       'Error fetching category at index 1:',


### PR DESCRIPTION
This PR fixes the categories API test by updating Redis key references to include the 'test:' prefix in test mode. The implementation was updated to use the 'test:' prefix for all Redis keys when running in test mode.