### PR TITLE
Fix transaction isolation test

### DIFF
--- a/tests/integration/performance/concurrent-operations/transaction-isolation.test.ts
+++ b/tests/integration/performance/concurrent-operations/transaction-isolation.test.ts
@@ -1,14 +1,15 @@
 /**
  * Transaction Isolation Test Module
- * 
+ *
  * Tests the application's ability to maintain transaction isolation properties
  * (Atomicity, Consistency, Isolation, Durability) during concurrent operations.
  */
 
-import { createMockRequest } from '../../setup';
+import { createMockRequest, setupTestEnvironment, clearTestData } from '../../setup';
 import { POST as createListing } from '../../../../src/app/api/sites/[siteSlug]/listings/route';
 import { DELETE as deleteListing } from '../../../../src/app/api/sites/[siteSlug]/listings/[listingSlug]/route';
 import { kv, redis } from '../../../../src/lib/redis-client';
+import { SiteConfig, Category, Listing } from '../../../../src/types';
 import { wait } from '../../setup';
 
 // Constants for transaction isolation tests
@@ -22,15 +23,15 @@ async function settlePromises<T>(promises: Promise<T>[]): Promise<{
   rejected: any[];
 }> {
   const results = await Promise.allSettled(promises);
-  
+
   const fulfilled = results
     .filter((result): result is PromiseFulfilledResult<T> => result.status === 'fulfilled')
     .map(result => result.value);
-    
+
   const rejected = results
     .filter((result): result is PromiseRejectedResult => result.status === 'rejected')
     .map(result => result.reason);
-    
+
   return {
     fulfilled,
     rejected,
@@ -38,43 +39,94 @@ async function settlePromises<T>(promises: Promise<T>[]): Promise<{
 }
 
 describe('Transaction Isolation', () => {
-  // Access test data from global setup
-  const { sites, categories } = global.__TEST_DATA__;
-  
+  // Setup test data
+  let sites: SiteConfig[];
+  let categories: Category[];
+  let listings: Listing[];
+
+  beforeAll(async () => {
+    // Set up test environment
+    console.log('Setting up test environment for transaction isolation tests...');
+    const testData = await setupTestEnvironment();
+    sites = testData.sites;
+    categories = testData.categories;
+    listings = testData.listings;
+
+    // Log test data for debugging
+    console.log(`Created ${sites.length} sites, ${categories.length} categories, and ${listings.length} listings`);
+    console.log('First site:', sites[0]);
+    console.log('First category:', categories[0]);
+
+    // Verify that we can access the test data through Redis
+    const firstSiteFromRedis = await kv.get(`test:site:slug:${sites[0].slug}`);
+    console.log('First site from Redis:', firstSiteFromRedis ? 'Found' : 'Not found');
+
+    if (!firstSiteFromRedis) {
+      console.warn('Test site not found in Redis, tests may fail!');
+    }
+  });
+
+  afterAll(async () => {
+    // Clean up test data
+    await clearTestData();
+  });
+
   it('should maintain atomicity during listing creation', async () => {
     // Get the first test site
     const site = sites[0];
-    
+    console.log('Using site for atomicity test:', site);
+
     // Get the first category
     const category = categories.find(c => c.siteId === site.id);
-    
+    console.log('Found category for atomicity test:', category);
+
     if (!category) {
       throw new Error('Test setup failed: No category found for the test site');
     }
-    
+
+    // Verify that the site exists in Redis
+    const siteFromRedis = await kv.get(`test:site:slug:${site.slug}`);
+    console.log('Site from Redis for atomicity test:', siteFromRedis ? 'Found' : 'Not found');
+
+    if (!siteFromRedis) {
+      console.log('Re-storing site in Redis for atomicity test...');
+      await kv.set(`test:site:slug:${site.slug}`, JSON.stringify(site));
+      await kv.set(`test:site:id:${site.id}`, JSON.stringify(site));
+    }
+
+    // Verify that the category exists in Redis
+    const categoryFromRedis = await kv.get(`test:category:id:${category.id}`);
+    console.log('Category from Redis for atomicity test:', categoryFromRedis ? 'Found' : 'Not found');
+
+    if (!categoryFromRedis) {
+      console.log('Re-storing category in Redis for atomicity test...');
+      await kv.set(`test:category:id:${category.id}`, JSON.stringify(category));
+      await kv.set(`test:category:site:${category.siteId}:${category.slug}`, JSON.stringify(category));
+    }
+
     // Create a spy on redis.exec to simulate occasional transaction failures
     const redisExecOriginal = redis.exec;
     const transactionResults: boolean[] = [];
-    
+
     redis.exec = jest.fn().mockImplementation(function() {
       // Randomly fail some transactions (about 30% failure rate)
       const shouldFail = Math.random() < 0.3;
       transactionResults.push(!shouldFail);
-      
+
       if (shouldFail) {
         return Promise.resolve(null); // Redis returns null for failed transactions
       }
-      
+
       // Otherwise execute the original method
       return redisExecOriginal.apply(this);
     });
-    
+
     try {
       // Create a batch of listing creation requests
       const createRequests = Array(TEST_BATCH_SIZE).fill(null).map((_, i) => {
         const uniqueId = `atomic-${Date.now()}-${i}`;
         const listingSlug = `atomic-test-listing-${uniqueId}`;
-        
+
         const request = createMockRequest(`/api/sites/${site.slug}/listings`, {
           method: 'POST',
           headers: {
@@ -92,52 +144,52 @@ describe('Transaction Isolation', () => {
             backlinkType: 'dofollow',
           }),
         });
-        
+
         return createListing(request, { params: { siteSlug: site.slug } });
       });
-      
+
       // Execute all requests
       const { fulfilled, rejected } = await settlePromises(createRequests);
-      
+
       // Check if we successfully simulated some transaction failures
       const failedTransactions = transactionResults.filter(result => !result).length;
       console.log(`Simulated ${failedTransactions} transaction failures out of ${transactionResults.length}`);
-      
+
       // Get all success responses
       const successResponses = fulfilled.filter(response => response.status === 201);
-      
+
       // Parse all successful listings
       const createdListings = await Promise.all(
         successResponses.map(async response => await response.json())
       );
-      
+
       // Verify transaction atomicity
       for (const listing of createdListings) {
         // Check that the listing exists in all expected Redis keys
         const byId = await kv.get(`test:listing:id:${listing.id}`);
         const bySlug = await kv.get(`test:listing:site:${site.id}:${listing.slug}`);
         const byCategoryAndSlug = await kv.get(`test:listing:category:${category.id}:${listing.slug}`);
-        
+
         // Either all of these should exist (transaction succeeded)
         // or none of them should exist (transaction failed)
         if (byId) {
           expect(bySlug).toBeTruthy();
           expect(byCategoryAndSlug).toBeTruthy();
-          
+
           // Verify the listing was also added to the site and category indexes
           const inSiteIndex = await redis.sismember(`test:site:${site.id}:listings`, listing.id);
           const inCategoryIndex = await redis.sismember(`test:category:${category.id}:listings`, listing.id);
-          
+
           expect(inSiteIndex).toBe(1);
           expect(inCategoryIndex).toBe(1);
         } else {
           expect(bySlug).toBeFalsy();
           expect(byCategoryAndSlug).toBeFalsy();
-          
+
           // Verify the listing was not added to the site and category indexes
           const inSiteIndex = await redis.sismember(`test:site:${site.id}:listings`, listing.id);
           const inCategoryIndex = await redis.sismember(`test:category:${category.id}:listings`, listing.id);
-          
+
           expect(inSiteIndex).toBe(0);
           expect(inCategoryIndex).toBe(0);
         }
@@ -147,26 +199,48 @@ describe('Transaction Isolation', () => {
       redis.exec = redisExecOriginal;
     }
   });
-  
+
   it('should maintain consistency during complex operations', async () => {
     // Get the first test site
     const site = sites[0];
-    
+    console.log('Using site:', site);
+
     // Get the first category
     const category = categories.find(c => c.siteId === site.id);
-    
+    console.log('Found category for site:', category);
+
     if (!category) {
       throw new Error('Test setup failed: No category found for the test site');
     }
-    
+
+    // Verify that the site exists in Redis
+    const siteFromRedis = await kv.get(`test:site:slug:${site.slug}`);
+    console.log('Site from Redis for consistency test:', siteFromRedis ? 'Found' : 'Not found');
+
+    if (!siteFromRedis) {
+      console.log('Re-storing site in Redis for consistency test...');
+      await kv.set(`test:site:slug:${site.slug}`, JSON.stringify(site));
+      await kv.set(`test:site:id:${site.id}`, JSON.stringify(site));
+    }
+
+    // Verify that the category exists in Redis
+    const categoryFromRedis = await kv.get(`test:category:id:${category.id}`);
+    console.log('Category from Redis for consistency test:', categoryFromRedis ? 'Found' : 'Not found');
+
+    if (!categoryFromRedis) {
+      console.log('Re-storing category in Redis for consistency test...');
+      await kv.set(`test:category:id:${category.id}`, JSON.stringify(category));
+      await kv.set(`test:category:site:${category.siteId}:${category.slug}`, JSON.stringify(category));
+    }
+
     // First, create a batch of test listings
     const listingSlugs: string[] = [];
-    
+
     for (let i = 0; i < TEST_BATCH_SIZE; i++) {
       const uniqueId = `consistency-${Date.now()}-${i}`;
       const listingSlug = `consistency-test-listing-${uniqueId}`;
       listingSlugs.push(listingSlug);
-      
+
       const request = createMockRequest(`/api/sites/${site.slug}/listings`, {
         method: 'POST',
         headers: {
@@ -184,98 +258,143 @@ describe('Transaction Isolation', () => {
           backlinkType: 'dofollow',
         }),
       });
-      
+
       const response = await createListing(request, { params: { siteSlug: site.slug } });
       expect(response.status).toBe(201);
     }
-    
+
     // Now, delete some of the listings and check for consistency
     const deleteRequests = listingSlugs.slice(0, Math.floor(TEST_BATCH_SIZE / 2)).map(slug => {
       const request = createMockRequest(`/api/sites/${site.slug}/listings/${slug}`, {
         method: 'DELETE',
       });
-      
-      return deleteListing(request, { 
-        params: { 
+
+      return deleteListing(request, {
+        params: {
           siteSlug: site.slug,
           listingSlug: slug
-        } 
+        }
       });
     });
-    
+
     // Execute all delete requests
     const { fulfilled } = await settlePromises(deleteRequests);
-    
+
     // All delete requests should succeed
     fulfilled.forEach(response => {
       expect(response.status).toBe(200);
     });
-    
+
     // Verify consistency: Each listing should either exist in all places or none
     for (const slug of listingSlugs) {
       // Get the listing by slug
       const listing = await kv.get(`test:listing:site:${site.id}:${slug}`);
-      
+
       if (listing) {
         // If listing exists, it should be in all the right places
         const byId = await kv.get(`test:listing:id:${listing.id}`);
         const byCategoryAndSlug = await kv.get(`test:listing:category:${category.id}:${slug}`);
-        
+
         expect(byId).toBeTruthy();
         expect(byCategoryAndSlug).toBeTruthy();
-        
+
         // Should be in indexes
         const inSiteIndex = await redis.sismember(`test:site:${site.id}:listings`, listing.id);
         const inCategoryIndex = await redis.sismember(`test:category:${category.id}:listings`, listing.id);
-        
+
         expect(inSiteIndex).toBe(1);
         expect(inCategoryIndex).toBe(1);
       } else {
         // If not found by slug, should not exist anywhere
         // First we need to get what the ID would have been
         const potentialId = `test-listing-site-${site.id}-${slug}`;
-        
+
         const byId = await kv.get(`test:listing:id:${potentialId}`);
         const byCategoryAndSlug = await kv.get(`test:listing:category:${category.id}:${slug}`);
-        
+
         expect(byId).toBeFalsy();
         expect(byCategoryAndSlug).toBeFalsy();
-        
+
         // Should not be in indexes
         const inSiteIndex = await redis.sismember(`test:site:${site.id}:listings`, potentialId);
         const inCategoryIndex = await redis.sismember(`test:category:${category.id}:listings`, potentialId);
-        
+
         expect(inSiteIndex).toBe(0);
         expect(inCategoryIndex).toBe(0);
       }
     }
   });
-  
+
   it('should maintain isolation between tenant data', async () => {
     // We need at least two sites for this test
     if (sites.length < 2) {
       throw new Error('Test setup failed: Need at least two test sites');
     }
-    
+
     const site1 = sites[0];
     const site2 = sites[1];
-    
+    console.log('Using sites:', site1.slug, site2.slug);
+
     // Get a category for each site
     const category1 = categories.find(c => c.siteId === site1.id);
     const category2 = categories.find(c => c.siteId === site2.id);
-    
-    if (!category1 || !category2) {
-      throw new Error('Test setup failed: Could not find categories for both test sites');
+    console.log('Found categories:',
+      category1 ? `${category1.id} for site ${site1.id}` : 'None for site1',
+      category2 ? `${category2.id} for site ${site2.id}` : 'None for site2'
+    );
+
+    // Verify that the sites exist in Redis
+    const site1FromRedis = await kv.get(`test:site:slug:${site1.slug}`);
+    const site2FromRedis = await kv.get(`test:site:slug:${site2.slug}`);
+    console.log('Sites from Redis:',
+      site1FromRedis ? 'Site1 found' : 'Site1 not found',
+      site2FromRedis ? 'Site2 found' : 'Site2 not found'
+    );
+
+    // Re-store sites if needed
+    if (!site1FromRedis) {
+      console.log('Re-storing site1 in Redis...');
+      await kv.set(`test:site:slug:${site1.slug}`, JSON.stringify(site1));
+      await kv.set(`test:site:id:${site1.id}`, JSON.stringify(site1));
     }
-    
+
+    if (!site2FromRedis) {
+      console.log('Re-storing site2 in Redis...');
+      await kv.set(`test:site:slug:${site2.slug}`, JSON.stringify(site2));
+      await kv.set(`test:site:id:${site2.id}`, JSON.stringify(site2));
+    }
+
+    // Verify that the categories exist in Redis
+    if (category1) {
+      const cat1FromRedis = await kv.get(`test:category:id:${category1.id}`);
+      if (!cat1FromRedis) {
+        console.log('Re-storing category1 in Redis...');
+        await kv.set(`test:category:id:${category1.id}`, JSON.stringify(category1));
+        await kv.set(`test:category:site:${category1.siteId}:${category1.slug}`, JSON.stringify(category1));
+      }
+    } else {
+      throw new Error('Test setup failed: Could not find category for site1');
+    }
+
+    if (category2) {
+      const cat2FromRedis = await kv.get(`test:category:id:${category2.id}`);
+      if (!cat2FromRedis) {
+        console.log('Re-storing category2 in Redis...');
+        await kv.set(`test:category:id:${category2.id}`, JSON.stringify(category2));
+        await kv.set(`test:category:site:${category2.siteId}:${category2.slug}`, JSON.stringify(category2));
+      }
+    } else {
+      throw new Error('Test setup failed: Could not find category for site2');
+    }
+
     // Create listings with the same slugs in both sites
     const sharedSlugs: string[] = [];
-    
+
     for (let i = 0; i < TEST_BATCH_SIZE; i++) {
       const uniqueId = `isolation-${Date.now()}-${i}`;
       const listingSlug = `isolation-test-listing-${uniqueId}`;
       sharedSlugs.push(listingSlug);
-      
+
       // Create listing in site 1
       const request1 = createMockRequest(`/api/sites/${site1.slug}/listings`, {
         method: 'POST',
@@ -294,7 +413,7 @@ describe('Transaction Isolation', () => {
           backlinkType: 'dofollow',
         }),
       });
-      
+
       // Create listing in site 2
       const request2 = createMockRequest(`/api/sites/${site2.slug}/listings`, {
         method: 'POST',
@@ -313,48 +432,48 @@ describe('Transaction Isolation', () => {
           backlinkType: 'dofollow',
         }),
       });
-      
+
       // Execute both requests
       const response1 = await createListing(request1, { params: { siteSlug: site1.slug } });
       const response2 = await createListing(request2, { params: { siteSlug: site2.slug } });
-      
+
       expect(response1.status).toBe(201);
       expect(response2.status).toBe(201);
     }
-    
+
     // Now verify isolation between the sites
     for (const slug of sharedSlugs) {
       // Get listings by slug from both sites
       const listing1 = await kv.get(`test:listing:site:${site1.id}:${slug}`);
       const listing2 = await kv.get(`test:listing:site:${site2.id}:${slug}`);
-      
+
       // Both should exist
       expect(listing1).toBeTruthy();
       expect(listing2).toBeTruthy();
-      
+
       // They should have different IDs
       expect(listing1.id).not.toBe(listing2.id);
-      
+
       // They should have different content
       expect(listing1.content).not.toBe(listing2.content);
       expect(listing1.content).toContain(site1.name);
       expect(listing2.content).toContain(site2.name);
-      
+
       // They should have different category IDs
       expect(listing1.categoryId).toBe(category1.id);
       expect(listing2.categoryId).toBe(category2.id);
-      
+
       // They should be in their respective site indexes only
       const inSite1Index = await redis.sismember(`test:site:${site1.id}:listings`, listing1.id);
       const inSite2Index = await redis.sismember(`test:site:${site2.id}:listings`, listing2.id);
-      
+
       expect(inSite1Index).toBe(1);
       expect(inSite2Index).toBe(1);
-      
+
       // They should not be in the other site's index
       const listing1InSite2 = await redis.sismember(`test:site:${site2.id}:listings`, listing1.id);
       const listing2InSite1 = await redis.sismember(`test:site:${site1.id}:listings`, listing2.id);
-      
+
       expect(listing1InSite2).toBe(0);
       expect(listing2InSite1).toBe(0);
     }

--- a/tests/integration/setup.ts
+++ b/tests/integration/setup.ts
@@ -217,9 +217,10 @@ export async function createTestCategories(sites: SiteConfig[]): Promise<Categor
 
   // Create categories for each site
   for (const site of sites) {
+    // Use site-specific category IDs to avoid collisions
     const siteCategories: Category[] = [
       {
-        id: `cat1`,  // Simple ID for first site's first category
+        id: `${site.id}_cat1`,  // Site-specific ID for first category
         siteId: site.id,
         name: 'Category 1',
         slug: 'category-1',
@@ -229,7 +230,7 @@ export async function createTestCategories(sites: SiteConfig[]): Promise<Categor
         updatedAt: timestamp,
       },
       {
-        id: `cat2`,  // Simple ID for first site's second category
+        id: `${site.id}_cat2`,  // Site-specific ID for second category
         siteId: site.id,
         name: 'Category 2',
         slug: 'category-2',
@@ -239,12 +240,12 @@ export async function createTestCategories(sites: SiteConfig[]): Promise<Categor
         updatedAt: timestamp,
       },
       {
-        id: `cat3`,  // Simple ID for first site's third category
+        id: `${site.id}_cat3`,  // Site-specific ID for third category
         siteId: site.id,
         name: 'Category 3',
         slug: 'category-3',
         metaDescription: 'Test category 3',
-        parentId: `cat1`, // Make this a subcategory
+        parentId: `${site.id}_cat1`, // Make this a subcategory with site-specific parent ID
         order: 3,
         createdAt: timestamp,
         updatedAt: timestamp,


### PR DESCRIPTION
This PR fixes the transaction isolation test by:

1. Using site-specific category IDs to prevent collisions between sites
2. Adding better verification of test data in Redis before running the tests
3. Re-storing test data in Redis if it's missing
4. Adding more detailed logging to help diagnose test failures

The test was failing because the category IDs were not unique across sites, causing the second site's categories to overwrite the first site's categories in Redis. This change ensures that each site has its own unique category IDs, which prevents collisions and allows the test to properly verify isolation between tenant data.