### PR TITLE
Fix AdminSidebar test

### DIFF
--- a/tests/admin/layout/AdminSidebar.test.tsx
+++ b/tests/admin/layout/AdminSidebar.test.tsx
@@ -5,7 +5,6 @@ import { AdminSidebar } from '@/components/admin/layout';
 // Mock next/navigation
 jest.mock('next/navigation', () => {
   return {
-    __esModule: true,
     usePathname: jest.fn().mockReturnValue('/admin/listings')
   };
 });


### PR DESCRIPTION
This PR fixes the AdminSidebar test by updating the usePathname mock. The test was failing because the mock was not being properly imported in the test.