### PR TITLE
Fix role-service tests

### DIFF
--- a/src/lib/__mocks__/redis-client.ts
+++ b/src/lib/__mocks__/redis-client.ts
@@ -1,0 +1,87 @@
+/**
+ * Mock Redis client for testing
+ */
+import redis from './redis';
+
+// Key-value interface for simplified Redis operations
+export const kv = {
+  get: async <T>(key: string): Promise<T | null> => {
+    try {
+      const value = await redis.get(key);
+      if (!value) return null;
+      try {
+        return JSON.parse(value) as T;
+      } catch (e) {
+        return value as unknown as T;
+      }
+    } catch (error) {
+      console.error(`[Redis] Error getting key ${key}:`, error);
+      return null;
+    }
+  },
+
+  set: async (key: string, value: any, options?: { ex?: number }): Promise<void> => {
+    try {
+      const serializedValue = typeof value === 'string' ? value : JSON.stringify(value);
+      if (options?.ex) {
+        await redis.expire(key, options.ex);
+      }
+      await redis.set(key, serializedValue);
+    } catch (error) {
+      console.error(`[Redis] Error setting key ${key}:`, error);
+    }
+  },
+
+  del: async (key: string): Promise<void> => {
+    try {
+      await redis.del(key);
+    } catch (error) {
+      console.error(`[Redis] Error deleting key ${key}:`, error);
+    }
+  },
+
+  keys: async (pattern: string): Promise<string[]> => {
+    try {
+      return await redis.keys(pattern);
+    } catch (error) {
+      console.error(`[Redis] Error getting keys with pattern ${pattern}:`, error);
+      return [];
+    }
+  },
+
+  // Add expire function for rate limiting
+  expire: async (key: string, seconds: number): Promise<void> => {
+    try {
+      await redis.expire(key, seconds);
+    } catch (error) {
+      console.error(`[Redis] Error setting expiry for key ${key}:`, error);
+    }
+  },
+
+  // Check connection status
+  isConnected: async (): Promise<boolean> => {
+    return true;
+  },
+
+  // Force reconnection
+  reconnect: (): void => {
+    // No-op for tests
+  },
+
+  // Get connection state
+  getConnectionState: (): string => {
+    return 'connected';
+  }
+};
+
+// Export the Redis client
+export { redis };
+
+// Export the MemoryRedis class
+export class MemoryRedis {
+  store: Map<string, any>;
+
+  constructor() {
+    this.store = new Map<string, any>();
+  }
+}

--- a/src/lib/__mocks__/redis.ts
+++ b/src/lib/__mocks__/redis.ts
@@ -1,0 +1,329 @@
+/**
+ * Mock Redis client for testing
+ */
+
+// In-memory Redis implementation that doesn't depend on ioredis
+class MemoryRedis {
+  store: Map<string, any>;
+
+  constructor() {
+    // Create a new store if it doesn't exist globally
+    if (typeof global !== 'undefined' && !global.inMemoryRedisStore) {
+      global.inMemoryRedisStore = new Map<string, any>();
+    }
+
+    // Use the global store if available, otherwise create a local one
+    this.store = (typeof global !== 'undefined' && global.inMemoryRedisStore)
+      ? global.inMemoryRedisStore
+      : new Map<string, any>();
+  }
+
+  // Basic Redis operations
+  async get(key: string): Promise<any> {
+    return this.store.get(key);
+  }
+
+  async set(key: string, value: string, ...args: any[]): Promise<'OK'> {
+    this.store.set(key, value);
+    return 'OK';
+  }
+
+  async del(...keys: string[]): Promise<number> {
+    let count = 0;
+    for (const key of keys) {
+      if (this.store.delete(key)) count++;
+    }
+    return count;
+  }
+
+  async keys(pattern: string): Promise<string[]> {
+    const wildcard = pattern.includes('*');
+    const prefix = pattern.replace('*', '');
+
+    const allKeys = Array.from(this.store.keys());
+
+    const matchingKeys = allKeys.filter(k =>
+      wildcard ? k.startsWith(prefix) : k === pattern
+    );
+
+    return matchingKeys;
+  }
+
+  // Set operations
+  async sadd(key: string, ...values: any[]): Promise<number> {
+    if (!this.store.has(key)) {
+      this.store.set(key, new Set());
+    }
+    const set = this.store.get(key);
+    let added = 0;
+    for (const value of values) {
+      const size = set.size;
+      set.add(value);
+      if (set.size > size) added++;
+    }
+    return added;
+  }
+
+  async smembers(key: string): Promise<string[]> {
+    if (!this.store.has(key)) return [];
+    return Array.from(this.store.get(key));
+  }
+
+  async srem(key: string, ...members: string[]): Promise<number> {
+    if (!this.store.has(key)) return 0;
+    const set = this.store.get(key);
+    let removed = 0;
+    for (const member of members) {
+      if (set.delete(member)) removed++;
+    }
+    return removed;
+  }
+
+  async sismember(key: string, member: string): Promise<number> {
+    if (!this.store.has(key)) return 0;
+    const set = this.store.get(key);
+    return set.has(member) ? 1 : 0;
+  }
+
+  async sinter(...keys: string[]): Promise<string[]> {
+    if (keys.length === 0) return [];
+
+    const sets: Set<string>[] = [];
+    for (const key of keys) {
+      if (!this.store.has(key)) return []; // Empty intersection
+      sets.push(new Set(this.store.get(key)));
+    }
+
+    if (sets.length === 0) return [];
+
+    const [firstSet, ...restSets] = sets;
+    const result = new Set(firstSet);
+
+    for (const item of result) {
+      if (!restSets.every(set => set.has(item))) {
+        result.delete(item);
+      }
+    }
+
+    return Array.from(result);
+  }
+
+  async scard(key: string): Promise<number> {
+    if (!this.store.has(key)) return 0;
+    return this.store.get(key).size;
+  }
+
+  // Hash operations
+  async hset(key: string, field: string, value: string): Promise<number> {
+    // Create a Map for the hash if it doesn't exist
+    if (!this.store.has(key)) {
+      this.store.set(key, new Map<string, string>());
+    }
+
+    const hash = this.store.get(key);
+    const isNew = !hash.has(field);
+
+    // Set the field-value pair
+    hash.set(field, value);
+
+    // Return 1 if field is new, 0 if field was updated
+    return isNew ? 1 : 0;
+  }
+
+  async hget(key: string, field: string): Promise<string | null> {
+    // Return null if hash doesn't exist
+    if (!this.store.has(key)) {
+      return null;
+    }
+
+    const hash = this.store.get(key);
+    const value = hash.get(field);
+
+    // Return null if field doesn't exist
+    return value !== undefined ? value : null;
+  }
+
+  async hdel(key: string, ...fields: string[]): Promise<number> {
+    // Return 0 if hash doesn't exist
+    if (!this.store.has(key)) {
+      return 0;
+    }
+
+    const hash = this.store.get(key);
+    let deleted = 0;
+
+    // Delete each field and count successful deletions
+    for (const field of fields) {
+      if (hash.delete(field)) {
+        deleted++;
+      }
+    }
+
+    // If hash is now empty, remove it
+    if (hash.size === 0) {
+      this.store.delete(key);
+    }
+
+    return deleted;
+  }
+
+  async hkeys(key: string): Promise<string[]> {
+    // Return empty array if hash doesn't exist
+    if (!this.store.has(key)) {
+      return [];
+    }
+
+    const hash = this.store.get(key);
+
+    // Return all field names
+    return Array.from(hash.keys());
+  }
+
+  async hgetall(key: string): Promise<Record<string, string> | null> {
+    // Return null if hash doesn't exist
+    if (!this.store.has(key)) {
+      return null;
+    }
+
+    const hash = this.store.get(key);
+    const result: Record<string, string> = {};
+
+    // Convert Map to plain object
+    for (const [field, value] of hash.entries()) {
+      result[field] = value;
+    }
+
+    return result;
+  }
+
+  async hmset(key: string, ...fieldValues: string[]): Promise<'OK'> {
+    // Create a Map for the hash if it doesn't exist
+    if (!this.store.has(key)) {
+      this.store.set(key, new Map<string, string>());
+    }
+
+    const hash = this.store.get(key);
+
+    // Process field-value pairs
+    for (let i = 0; i < fieldValues.length; i += 2) {
+      const field = fieldValues[i];
+      const value = fieldValues[i + 1];
+
+      if (field && value !== undefined) {
+        hash.set(field, value);
+      }
+    }
+
+    return 'OK';
+  }
+
+  async hincrby(key: string, field: string, increment: number): Promise<number> {
+    // Create a Map for the hash if it doesn't exist
+    if (!this.store.has(key)) {
+      this.store.set(key, new Map<string, string>());
+    }
+
+    const hash = this.store.get(key);
+
+    // Get current value or default to 0
+    const currentValue = hash.has(field) ? parseInt(hash.get(field), 10) : 0;
+
+    // Calculate new value
+    const newValue = currentValue + increment;
+
+    // Store new value
+    hash.set(field, newValue.toString());
+
+    return newValue;
+  }
+
+  // Transaction support
+  multi(): any {
+    const commands: { cmd: string; args: any[] }[] = [];
+
+    const exec = async (): Promise<Array<[Error | null, any]>> => {
+      const results: Array<[Error | null, any]> = [];
+
+      for (const { cmd, args } of commands) {
+        try {
+          // @ts-ignore - We know these methods exist
+          const result = await this[cmd](...args);
+          results.push([null, result]);
+        } catch (error) {
+          results.push([error as Error, null]);
+        }
+      }
+
+      return results;
+    };
+
+    // Helper to add commands to the transaction
+    const addCommand = (cmd: string) => {
+      return (...args: any[]) => {
+        commands.push({ cmd, args });
+        return multi;
+      };
+    };
+
+    // Build multi object with methods
+    const multi = {
+      exec,
+      get: addCommand('get'),
+      set: addCommand('set'),
+      del: addCommand('del'),
+      keys: addCommand('keys'),
+      sadd: addCommand('sadd'),
+      srem: addCommand('srem'),
+      smembers: addCommand('smembers'),
+      sismember: addCommand('sismember'),
+      sinter: addCommand('sinter'),
+      scard: addCommand('scard'),
+      // Hash operations
+      hset: addCommand('hset'),
+      hget: addCommand('hget'),
+      hdel: addCommand('hdel'),
+      hkeys: addCommand('hkeys'),
+      hgetall: addCommand('hgetall'),
+      hmset: addCommand('hmset'),
+      hincrby: addCommand('hincrby'),
+    };
+
+    return multi;
+  }
+
+  // Expiration support
+  async expire(key: string, seconds: number): Promise<number> {
+    if (!this.store.has(key)) return 0;
+
+    // Schedule deletion after the specified seconds
+    setTimeout(() => {
+      if (this.store.has(key)) {
+        this.store.delete(key);
+      }
+    }, seconds * 1000);
+
+    return 1;
+  }
+
+  // Utility
+  async ping(): Promise<string> {
+    return 'PONG';
+  }
+
+  // Clear all data (for testing)
+  async flushall(): Promise<'OK'> {
+    this.store.clear();
+    return 'OK';
+  }
+}
+
+// Create a singleton instance of the in-memory Redis client
+const redis = new MemoryRedis();
+
+// Declare global memory store for persistence across API routes
+declare global {
+  var inMemoryRedisStore: Map<string, any>;
+}
+
+// Export the Redis client
+export default redis;

--- a/src/lib/audit/__mocks__/audit-service.ts
+++ b/src/lib/audit/__mocks__/audit-service.ts
@@ -1,0 +1,338 @@
+/**
+ * Mock Audit Service for testing
+ */
+import { v4 as uuidv4 } from 'uuid';
+import { 
+  AuditEvent, 
+  AuditEventInput, 
+  AuditEventQuery, 
+  AuditAction, 
+  AuditSeverity,
+  DEFAULT_SEVERITY_MAP
+} from '../types';
+
+// Store events in memory for testing
+const auditEvents: AuditEvent[] = [];
+
+export class AuditService {
+  private static GLOBAL_TENANT_ID = 'global';
+
+  /**
+   * Create a new audit event
+   */
+  public static async logEvent(event: AuditEventInput): Promise<AuditEvent> {
+    try {
+      // Generate ID and timestamp
+      const id = uuidv4();
+      const timestamp = new Date().toISOString();
+      
+      // Set default severity if not provided
+      const severity = event.severity || 
+        (event.action in DEFAULT_SEVERITY_MAP ? DEFAULT_SEVERITY_MAP[event.action] : AuditSeverity.INFO);
+      
+      // Create the complete audit event
+      const auditEvent: AuditEvent = {
+        ...event,
+        id,
+        timestamp,
+        severity
+      };
+      
+      // Store the audit event in memory
+      auditEvents.push(auditEvent);
+      
+      return auditEvent;
+    } catch (error) {
+      console.error('Error logging audit event:', error);
+      
+      // Return a minimal version of the event
+      return {
+        ...event,
+        id: 'error',
+        timestamp: new Date().toISOString(),
+        severity: AuditSeverity.ERROR,
+        details: { error: 'Failed to log audit event', ...event.details }
+      };
+    }
+  }
+
+  /**
+   * Helper method to log permission-related events
+   */
+  public static async logPermissionEvent(
+    userId: string,
+    tenantId: string,
+    resourceType: string,
+    permission: string,
+    success: boolean,
+    resourceId?: string,
+    details: Record<string, any> = {}
+  ): Promise<AuditEvent> {
+    const action = success ? AuditAction.ACCESS_GRANTED : AuditAction.ACCESS_DENIED;
+    
+    return AuditService.logEvent({
+      userId,
+      tenantId,
+      action,
+      resourceType,
+      resourceId,
+      severity: success ? AuditSeverity.INFO : AuditSeverity.WARNING,
+      details: {
+        permission,
+        ...details
+      },
+      success
+    });
+  }
+
+  /**
+   * Helper method to log user authentication events
+   */
+  public static async logAuthEvent(
+    userId: string,
+    tenantId: string,
+    success: boolean,
+    details: Record<string, any> = {}
+  ): Promise<AuditEvent> {
+    return AuditService.logEvent({
+      userId,
+      tenantId,
+      action: AuditAction.USER_LOGIN,
+      severity: success ? AuditSeverity.INFO : AuditSeverity.WARNING,
+      details,
+      success
+    });
+  }
+
+  /**
+   * Helper method to log role management events
+   */
+  public static async logRoleEvent(
+    userId: string,
+    tenantId: string,
+    action: AuditAction.ROLE_CREATED | AuditAction.ROLE_UPDATED | AuditAction.ROLE_DELETED,
+    roleId: string,
+    details: Record<string, any> = {}
+  ): Promise<AuditEvent> {
+    return AuditService.logEvent({
+      userId,
+      tenantId,
+      action,
+      resourceType: 'role',
+      resourceId: roleId,
+      details,
+      success: true
+    });
+  }
+
+  /**
+   * Helper method to log tenant membership events
+   */
+  public static async logTenantMembershipEvent(
+    adminUserId: string,
+    tenantId: string,
+    targetUserId: string,
+    action: AuditAction.USER_ADDED_TO_TENANT | AuditAction.USER_REMOVED_FROM_TENANT,
+    details: Record<string, any> = {}
+  ): Promise<AuditEvent> {
+    return AuditService.logEvent({
+      userId: adminUserId,
+      tenantId,
+      action,
+      resourceType: 'user',
+      resourceId: targetUserId,
+      details: {
+        targetUserId,
+        ...details
+      },
+      success: true
+    });
+  }
+
+  /**
+   * Helper method to log cross-tenant access attempts
+   */
+  public static async logCrossTenantAccessAttempt(
+    userId: string,
+    sourceTenantId: string,
+    targetTenantId: string,
+    details: Record<string, any> = {}
+  ): Promise<AuditEvent> {
+    return AuditService.logEvent({
+      userId,
+      tenantId: sourceTenantId,
+      action: AuditAction.CROSS_TENANT_ACCESS_ATTEMPT,
+      severity: AuditSeverity.ERROR,
+      details: {
+        targetTenantId,
+        ...details
+      },
+      success: false
+    });
+  }
+
+  /**
+   * Get an audit event by ID
+   */
+  public static async getEventById(id: string, tenantId?: string): Promise<AuditEvent | null> {
+    try {
+      const event = auditEvents.find(e => e.id === id);
+      
+      if (!event) {
+        return null;
+      }
+      
+      // If tenantId is provided, enforce tenant isolation
+      if (tenantId && event.tenantId !== tenantId) {
+        console.warn(`Tenant isolation violation: User from tenant ${tenantId} attempted to access event from tenant ${event.tenantId}`);
+        return null;
+      }
+      
+      return event;
+    } catch (error) {
+      console.error('Error retrieving audit event:', error);
+      return null;
+    }
+  }
+
+  /**
+   * Query audit events with various filters
+   */
+  public static async queryEvents(
+    query: AuditEventQuery,
+    userTenantContext: string,
+    isGlobalAdmin: boolean = false
+  ): Promise<AuditEvent[]> {
+    try {
+      // Enforce tenant isolation unless user is a global admin
+      const tenantId = isGlobalAdmin ? (query.tenantId || 'all') : userTenantContext;
+      
+      // Filter events
+      return auditEvents.filter(event => {
+        // Always enforce tenant isolation unless global admin
+        if (!isGlobalAdmin && event.tenantId !== userTenantContext) {
+          return false;
+        }
+        
+        // Filter by tenant
+        if (tenantId !== 'all' && event.tenantId !== tenantId) {
+          return false;
+        }
+        
+        // Filter by user
+        if (query.userId && event.userId !== query.userId) {
+          return false;
+        }
+        
+        // Filter by resource type
+        if (query.resourceType && event.resourceType !== query.resourceType) {
+          return false;
+        }
+        
+        // Filter by resource ID
+        if (query.resourceId && event.resourceId !== query.resourceId) {
+          return false;
+        }
+        
+        // Filter by action (if string)
+        if (query.action && !Array.isArray(query.action) && event.action !== query.action) {
+          return false;
+        }
+        
+        // Filter by action (if array)
+        if (query.action && Array.isArray(query.action) && !query.action.includes(event.action)) {
+          return false;
+        }
+        
+        // Filter by severity (if string)
+        if (query.severity && !Array.isArray(query.severity) && event.severity !== query.severity) {
+          return false;
+        }
+        
+        // Filter by severity (if array)
+        if (query.severity && Array.isArray(query.severity) && !query.severity.includes(event.severity)) {
+          return false;
+        }
+        
+        // Filter by success
+        if (query.success !== undefined && event.success !== query.success) {
+          return false;
+        }
+        
+        // Filter by date range
+        if (query.startDate && new Date(event.timestamp) < new Date(query.startDate)) {
+          return false;
+        }
+        
+        if (query.endDate && new Date(event.timestamp) > new Date(query.endDate)) {
+          return false;
+        }
+        
+        return true;
+      });
+    } catch (error) {
+      console.error('Error querying audit events:', error);
+      return [];
+    }
+  }
+
+  /**
+   * Get recent audit events for a specific tenant
+   */
+  public static async getRecentEvents(
+    tenantId: string,
+    limit: number = 50,
+    offset: number = 0
+  ): Promise<AuditEvent[]> {
+    // Apply safe limits
+    const safeLimit = Math.min(limit, 1000);
+    const safeOffset = Math.max(offset, 0);
+    
+    return AuditService.queryEvents(
+      {
+        tenantId,
+        limit: safeLimit,
+        offset: safeOffset
+      },
+      tenantId,
+      true // Skip tenant isolation check
+    );
+  }
+
+  /**
+   * Delete audit events older than the retention period
+   */
+  public static async pruneOldEvents(retentionDays: number = 90): Promise<number> {
+    try {
+      const cutoffTime = Date.now() - (retentionDays * 24 * 60 * 60 * 1000);
+      const cutoffDate = new Date(cutoffTime);
+      
+      // Count events to delete
+      const eventsToDelete = auditEvents.filter(event => 
+        new Date(event.timestamp) < cutoffDate
+      );
+      
+      // Remove events from the array
+      for (const event of eventsToDelete) {
+        const index = auditEvents.indexOf(event);
+        if (index !== -1) {
+          auditEvents.splice(index, 1);
+        }
+      }
+      
+      return eventsToDelete.length;
+    } catch (error) {
+      console.error('Error pruning old audit events:', error);
+      return 0;
+    }
+  }
+
+  /**
+   * Clear all audit events (for testing)
+   */
+  public static clearEvents(): void {
+    auditEvents.length = 0;
+  }
+}
+
+export default AuditService;


### PR DESCRIPTION
This PR fixes the role-service tests by:

1. Adding mock implementations for the audit-service module
2. Adding mock implementations for the redis and redis-client modules
3. Updating the role-service tests to use the mock implementations
4. Fixing assertions to match the behavior of the mock implementations

These changes ensure that the tests pass and provide a better foundation for future development.