### PR TITLE
Fix site form tests

### DIFF
--- a/src/components/admin/sites/hooks/useSites/validation.ts
+++ b/src/components/admin/sites/hooks/useSites/validation.ts
@@ -4,7 +4,7 @@ import { SiteData, SiteErrors } from './types';
 
 /**
  * Validates site data based on the specified section
- * 
+ *
  * @param site - Site data to validate
  * @param section - Optional section to validate (basic, domains, theme, seo, settings)
  * @returns Object with errors and isValid flag
@@ -12,7 +12,7 @@ import { SiteData, SiteErrors } from './types';
 export const validateSite = (site: SiteData, section?: string): { errors: SiteErrors; isValid: boolean } => {
   const errors: SiteErrors = {};
   let isValid = true;
-  
+
   // Basic Info validation
   if (!section || section === 'basic') {
     if (!site.name?.trim()) {
@@ -22,7 +22,7 @@ export const validateSite = (site: SiteData, section?: string): { errors: SiteEr
       errors.name = 'Name cannot exceed 50 characters';
       isValid = false;
     }
-    
+
     if (!site.slug?.trim()) {
       errors.slug = 'Slug is required';
       isValid = false;
@@ -33,13 +33,13 @@ export const validateSite = (site: SiteData, section?: string): { errors: SiteEr
       errors.slug = 'Slug cannot exceed 50 characters';
       isValid = false;
     }
-    
+
     if (site.description && site.description.length > 500) {
       errors.description = 'Description cannot exceed 500 characters';
       isValid = false;
     }
   }
-  
+
   // Domain validation
   if (!section || section === 'domains') {
     if (!site.domains || site.domains.length === 0) {
@@ -47,7 +47,7 @@ export const validateSite = (site: SiteData, section?: string): { errors: SiteEr
       isValid = false;
     }
   }
-  
+
   // Theme validation
   if (!section || section === 'theme') {
     if (site.customStyles) {
@@ -55,7 +55,7 @@ export const validateSite = (site: SiteData, section?: string): { errors: SiteEr
         // Simple check for balanced braces
         const openBraces = (site.customStyles.match(/{/g) || []).length;
         const closeBraces = (site.customStyles.match(/}/g) || []).length;
-        
+
         if (openBraces !== closeBraces) {
           errors.customStyles = 'CSS syntax error: unbalanced braces';
           isValid = false;
@@ -66,32 +66,32 @@ export const validateSite = (site: SiteData, section?: string): { errors: SiteEr
       }
     }
   }
-  
+
   // SEO validation
   if (!section || section === 'seo') {
     if (site.seoTitle && site.seoTitle.length > 60) {
       errors.seoTitle = 'SEO title should be 60 characters or less';
       isValid = false;
     }
-    
+
     if (site.seoDescription && site.seoDescription.length > 160) {
       errors.seoDescription = 'SEO description should be 160 characters or less';
       isValid = false;
     }
   }
-  
+
   // Settings validation
   if (!section || section === 'settings') {
-    if (site.listingsPerPage && (site.listingsPerPage <= 0 || site.listingsPerPage > 100)) {
+    if (site.listingsPerPage !== undefined && (site.listingsPerPage <= 0 || site.listingsPerPage > 100)) {
       errors.listingsPerPage = 'Listings per page must be between 1 and 100';
       isValid = false;
     }
-    
+
     if (site.contactEmail && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(site.contactEmail)) {
       errors.contactEmail = 'Please enter a valid email address';
       isValid = false;
     }
   }
-  
+
   return { errors, isValid };
 };

--- a/tests/admin/sites/components/BasicInfoStep.validation.test.tsx
+++ b/tests/admin/sites/components/BasicInfoStep.validation.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { BasicInfoStep } from '@/components/admin/sites/components/BasicInfoStep';
+import BasicInfoStep from '@/components/admin/sites/components/BasicInfoStep';
 
 describe('BasicInfoStep Component - Validation', () => {
   // Mock form values
@@ -9,25 +9,25 @@ describe('BasicInfoStep Component - Validation', () => {
     slug: 'test-site',
     description: 'This is a test description'
   };
-  
+
   // Mock functions
   const mockOnChange = jest.fn();
-  
+
   it('displays error message for name field when provided', () => {
     const mockErrors = {
       name: 'Site name is required'
     };
-    
+
     render(
-      <BasicInfoStep 
+      <BasicInfoStep
         values={mockValues}
         onChange={mockOnChange}
         errors={mockErrors}
       />
     );
-    
+
     // Check if error message is displayed
-    const errorElement = screen.getByTestId('site-form-name-error');
+    const errorElement = screen.getByTestId('siteForm-name-error');
     expect(errorElement).toBeInTheDocument();
     expect(errorElement).toHaveTextContent('Site name is required');
   });
@@ -36,17 +36,17 @@ describe('BasicInfoStep Component - Validation', () => {
     const mockErrors = {
       slug: 'Slug must contain only lowercase letters, numbers, and hyphens'
     };
-    
+
     render(
-      <BasicInfoStep 
+      <BasicInfoStep
         values={mockValues}
         onChange={mockOnChange}
         errors={mockErrors}
       />
     );
-    
+
     // Check if error message is displayed
-    const errorElement = screen.getByTestId('site-form-slug-error');
+    const errorElement = screen.getByTestId('siteForm-slug-error');
     expect(errorElement).toBeInTheDocument();
     expect(errorElement).toHaveTextContent('Slug must contain only lowercase letters, numbers, and hyphens');
   });
@@ -56,37 +56,37 @@ describe('BasicInfoStep Component - Validation', () => {
       name: 'Site name is required',
       slug: 'Invalid slug format'
     };
-    
+
     render(
-      <BasicInfoStep 
+      <BasicInfoStep
         values={mockValues}
         onChange={mockOnChange}
         errors={mockErrors}
       />
     );
-    
+
     // Check if input fields have error class
-    const nameInput = screen.getByTestId('site-form-name');
-    const slugInput = screen.getByTestId('site-form-slug');
-    
-    expect(nameInput).toHaveClass('error', { exact: false });
-    expect(slugInput).toHaveClass('error', { exact: false });
+    const nameInput = screen.getByTestId('siteForm-name');
+    const slugInput = screen.getByTestId('siteForm-slug');
+
+    expect(nameInput).toHaveClass('border-red-500', { exact: false });
+    expect(slugInput).toHaveClass('border-red-500', { exact: false });
   });
 
   it('does not show error elements when no errors are provided', () => {
     const mockErrors = {};
-    
+
     render(
-      <BasicInfoStep 
+      <BasicInfoStep
         values={mockValues}
         onChange={mockOnChange}
         errors={mockErrors}
       />
     );
-    
+
     // Error elements should not be in the document
-    expect(screen.queryByTestId('site-form-name-error')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('site-form-slug-error')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('site-form-description-error')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('siteForm-name-error')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('siteForm-slug-error')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('siteForm-description-error')).not.toBeInTheDocument();
   });
 });

--- a/tests/admin/sites/components/FormActions.interaction.test.tsx
+++ b/tests/admin/sites/components/FormActions.interaction.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { FormActions } from '@/components/admin/sites/components/FormActions';
+import FormActions from '@/components/admin/sites/components/FormActions';
 
 describe('FormActions Component - Interaction', () => {
   // Setup test user for interactions
@@ -23,7 +23,7 @@ describe('FormActions Component - Interaction', () => {
     );
 
     // Click the next button
-    const nextButton = screen.getByTestId('form-next-button');
+    const nextButton = screen.getByTestId('next-button');
     await user.click(nextButton);
 
     // Verify callback was called
@@ -108,7 +108,7 @@ describe('FormActions Component - Interaction', () => {
 
     // Tab to the next button
     await user.tab();
-    expect(screen.getByTestId('form-next-button')).toHaveFocus();
+    expect(screen.getByTestId('next-button')).toHaveFocus();
 
     // Press Space to click
     await user.keyboard(' ');


### PR DESCRIPTION
This PR fixes several site form tests:

1. useSites.validation.test.ts - Fixed validation for listingsPerPage field
2. BasicInfoStep.validation.test.tsx - Updated import to use default export and fixed test assertions
3. FormActions.interaction.test.tsx - Updated import to use default export and fixed test assertions

These changes ensure that the tests pass and provide a better foundation for future development.