### PR TITLE
Fix BasicInfoStep component and tests

### DIFF
--- a/src/components/admin/sites/components/BasicInfoStep.tsx
+++ b/src/components/admin/sites/components/BasicInfoStep.tsx
@@ -1,12 +1,13 @@
 'use client';
 
 import React from 'react';
+import { useSiteForm } from '../context/SiteFormContext';
 
 export interface BasicInfoStepProps {
   /**
    * Form values for basic site information
    */
-  values: {
+  values?: {
     name: string;
     slug: string;
     description: string;
@@ -14,7 +15,7 @@ export interface BasicInfoStepProps {
   /**
    * Errors for form validation
    */
-  errors: {
+  errors?: {
     name?: string;
     slug?: string;
     description?: string;
@@ -22,38 +23,60 @@ export interface BasicInfoStepProps {
   /**
    * Handler for input changes
    */
-  onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
+  onValueChange?: (field: string, value: any) => void;
   /**
    * Is the form in a loading state
    */
-  isLoading?: boolean;
+  loading?: boolean;
 }
 
 /**
  * BasicInfoStep - Form step for site name, slug, and description
- * 
+ *
  * First step in the site creation/editing process
  */
 export const BasicInfoStep: React.FC<BasicInfoStepProps> = ({
-  values,
-  errors,
-  onChange,
-  isLoading = false
+  values: propValues,
+  errors: propErrors,
+  onValueChange,
+  loading = false
 }) => {
+  // Use context if available, otherwise use props
+  let siteFormContext = null;
+  try {
+    if (typeof useSiteForm === 'function') {
+      siteFormContext = useSiteForm();
+    }
+  } catch (error) {
+    // If context is not available, we'll use props instead
+    siteFormContext = null;
+  }
+
+  const values = propValues || (siteFormContext?.state.formData || { name: '', slug: '', description: '' });
+  const errors = propErrors || (siteFormContext?.state.errors || {});
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { name, value } = e.target;
+    if (onValueChange) {
+      onValueChange(name, value);
+    } else if (siteFormContext) {
+      siteFormContext.updateField(name, value);
+    }
+  };
   return (
-    <fieldset 
-      className="mb-6" 
-      disabled={isLoading}
+    <fieldset
+      className="mb-6"
+      disabled={loading}
       data-testid="siteForm-fieldset"
     >
       <legend className="text-lg font-semibold mb-3" data-testid="siteForm-basic-info-heading">
         Basic Information
       </legend>
-      
+
       {/* Name field */}
       <div className="mb-4">
-        <label 
-          htmlFor="siteForm-name" 
+        <label
+          htmlFor="siteForm-name"
           className="block text-sm font-medium mb-1"
         >
           Site Name *
@@ -63,16 +86,16 @@ export const BasicInfoStep: React.FC<BasicInfoStepProps> = ({
           id="siteForm-name"
           name="name"
           value={values.name}
-          onChange={onChange}
+          onChange={handleChange}
           className={`w-full p-2 border rounded focus:ring-2 focus:border-blue-500 ${errors.name ? 'border-red-500' : 'border-gray-300'}`}
           aria-invalid={errors.name ? "true" : "false"}
           aria-describedby={errors.name ? "siteForm-name-error" : undefined}
           data-testid="siteForm-name"
         />
         {errors.name && (
-          <p 
-            className="mt-1 text-sm text-red-500" 
-            role="alert" 
+          <p
+            className="mt-1 text-sm text-red-500"
+            role="alert"
             id="siteForm-name-error"
             data-testid="siteForm-name-error"
           >
@@ -80,11 +103,11 @@ export const BasicInfoStep: React.FC<BasicInfoStepProps> = ({
           </p>
         )}
       </div>
-      
+
       {/* Slug field */}
       <div className="mb-4">
-        <label 
-          htmlFor="siteForm-slug" 
+        <label
+          htmlFor="siteForm-slug"
           className="block text-sm font-medium mb-1"
         >
           Slug * <span className="text-xs text-gray-500">(URL-friendly name)</span>
@@ -94,16 +117,16 @@ export const BasicInfoStep: React.FC<BasicInfoStepProps> = ({
           id="siteForm-slug"
           name="slug"
           value={values.slug}
-          onChange={onChange}
+          onChange={handleChange}
           className={`w-full p-2 border rounded focus:ring-2 focus:border-blue-500 ${errors.slug ? 'border-red-500' : 'border-gray-300'}`}
           aria-invalid={errors.slug ? "true" : "false"}
           aria-describedby={errors.slug ? "siteForm-slug-error" : undefined}
           data-testid="siteForm-slug"
         />
         {errors.slug && (
-          <p 
-            className="mt-1 text-sm text-red-500" 
-            role="alert" 
+          <p
+            className="mt-1 text-sm text-red-500"
+            role="alert"
             id="siteForm-slug-error"
             data-testid="siteForm-slug-error"
           >
@@ -111,11 +134,11 @@ export const BasicInfoStep: React.FC<BasicInfoStepProps> = ({
           </p>
         )}
       </div>
-      
+
       {/* Description field */}
       <div className="mb-4">
-        <label 
-          htmlFor="siteForm-description" 
+        <label
+          htmlFor="siteForm-description"
           className="block text-sm font-medium mb-1"
         >
           Description <span className="text-xs text-gray-500">(Optional)</span>
@@ -124,7 +147,7 @@ export const BasicInfoStep: React.FC<BasicInfoStepProps> = ({
           id="siteForm-description"
           name="description"
           value={values.description}
-          onChange={onChange}
+          onChange={handleChange}
           rows={3}
           className={`w-full p-2 border rounded focus:ring-2 focus:border-blue-500 ${errors.description ? 'border-red-500' : 'border-gray-300'}`}
           aria-invalid={errors.description ? "true" : "false"}
@@ -132,9 +155,9 @@ export const BasicInfoStep: React.FC<BasicInfoStepProps> = ({
           data-testid="siteForm-description"
         />
         {errors.description && (
-          <p 
-            className="mt-1 text-sm text-red-500" 
-            role="alert" 
+          <p
+            className="mt-1 text-sm text-red-500"
+            role="alert"
             id="siteForm-description-error"
             data-testid="siteForm-description-error"
           >

--- a/src/components/admin/sites/context/SiteFormContext.tsx
+++ b/src/components/admin/sites/context/SiteFormContext.tsx
@@ -1,0 +1,150 @@
+import React, { createContext, useContext, useReducer, ReactNode } from 'react';
+
+// Define the shape of our form data
+interface SiteFormData {
+  name: string;
+  slug: string;
+  description: string;
+  [key: string]: any;
+}
+
+// Define the shape of our form errors
+interface SiteFormErrors {
+  [key: string]: string;
+}
+
+// Define the shape of our form state
+interface SiteFormState {
+  formData: SiteFormData;
+  errors: SiteFormErrors;
+  isSubmitting: boolean;
+  isValid: boolean;
+}
+
+// Define the actions we can dispatch
+type SiteFormAction =
+  | { type: 'UPDATE_FIELD'; field: string; value: any }
+  | { type: 'SET_ERRORS'; errors: SiteFormErrors }
+  | { type: 'SUBMIT_START' }
+  | { type: 'SUBMIT_SUCCESS' }
+  | { type: 'SUBMIT_ERROR'; errors: SiteFormErrors }
+  | { type: 'RESET_FORM' };
+
+// Define the context type
+interface SiteFormContextType {
+  state: SiteFormState;
+  updateField: (field: string, value: any) => void;
+  setErrors: (errors: SiteFormErrors) => void;
+  submitForm: () => void;
+  resetForm: () => void;
+}
+
+// Create the context
+const SiteFormContext = createContext<SiteFormContextType | undefined>(undefined);
+
+// Initial state
+const initialState: SiteFormState = {
+  formData: {
+    name: '',
+    slug: '',
+    description: ''
+  },
+  errors: {},
+  isSubmitting: false,
+  isValid: false
+};
+
+// Reducer function
+function siteFormReducer(state: SiteFormState, action: SiteFormAction): SiteFormState {
+  switch (action.type) {
+    case 'UPDATE_FIELD':
+      return {
+        ...state,
+        formData: {
+          ...state.formData,
+          [action.field]: action.value
+        }
+      };
+    case 'SET_ERRORS':
+      return {
+        ...state,
+        errors: action.errors,
+        isValid: Object.keys(action.errors).length === 0
+      };
+    case 'SUBMIT_START':
+      return {
+        ...state,
+        isSubmitting: true
+      };
+    case 'SUBMIT_SUCCESS':
+      return {
+        ...state,
+        isSubmitting: false,
+        errors: {}
+      };
+    case 'SUBMIT_ERROR':
+      return {
+        ...state,
+        isSubmitting: false,
+        errors: action.errors,
+        isValid: false
+      };
+    case 'RESET_FORM':
+      return initialState;
+    default:
+      return state;
+  }
+}
+
+// Provider component
+interface SiteFormProviderProps {
+  children: ReactNode;
+  initialData?: Partial<SiteFormData>;
+}
+
+export const SiteFormProvider: React.FC<SiteFormProviderProps> = ({ 
+  children, 
+  initialData = {} 
+}) => {
+  const [state, dispatch] = useReducer(siteFormReducer, {
+    ...initialState,
+    formData: {
+      ...initialState.formData,
+      ...initialData
+    }
+  });
+
+  const updateField = (field: string, value: any) => {
+    dispatch({ type: 'UPDATE_FIELD', field, value });
+  };
+
+  const setErrors = (errors: SiteFormErrors) => {
+    dispatch({ type: 'SET_ERRORS', errors });
+  };
+
+  const submitForm = () => {
+    dispatch({ type: 'SUBMIT_START' });
+    // Actual submission logic would go here
+  };
+
+  const resetForm = () => {
+    dispatch({ type: 'RESET_FORM' });
+  };
+
+  return (
+    <SiteFormContext.Provider value={{ state, updateField, setErrors, submitForm, resetForm }}>
+      {children}
+    </SiteFormContext.Provider>
+  );
+};
+
+// Hook for using the context
+export const useSiteForm = () => {
+  const context = useContext(SiteFormContext);
+  if (context === undefined) {
+    throw new Error('useSiteForm must be used within a SiteFormProvider');
+  }
+  return context;
+};
+
+export default SiteFormProvider;

--- a/tests/admin/sites/components/BasicInfoStep.test.tsx
+++ b/tests/admin/sites/components/BasicInfoStep.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import BasicInfoStep from '@/components/admin/sites/components/BasicInfoStep';
+import { SiteFormProvider } from '@/components/admin/sites/context/SiteFormContext';
 
 describe('BasicInfoStep Component - Basic Rendering', () => {
   // Mock form values
@@ -16,11 +17,13 @@ describe('BasicInfoStep Component - Basic Rendering', () => {
 
   it('renders all form fields correctly', () => {
     render(
-      <BasicInfoStep
-        values={mockValues}
-        onChange={mockOnChange}
-        errors={mockErrors}
-      />
+      <SiteFormProvider>
+        <BasicInfoStep
+          values={mockValues}
+          onValueChange={mockOnChange}
+          errors={mockErrors}
+        />
+      </SiteFormProvider>
     );
 
     // Check if all form fields are rendered
@@ -42,11 +45,13 @@ describe('BasicInfoStep Component - Basic Rendering', () => {
     };
 
     render(
-      <BasicInfoStep
-        values={valuesWithData}
-        onChange={mockOnChange}
-        errors={mockErrors}
-      />
+      <SiteFormProvider>
+        <BasicInfoStep
+          values={valuesWithData}
+          onValueChange={mockOnChange}
+          errors={mockErrors}
+        />
+      </SiteFormProvider>
     );
 
     // Check if values are displayed in form fields
@@ -57,11 +62,13 @@ describe('BasicInfoStep Component - Basic Rendering', () => {
 
   it('shows helper text for form fields', () => {
     render(
-      <BasicInfoStep
-        values={mockValues}
-        onChange={mockOnChange}
-        errors={mockErrors}
-      />
+      <SiteFormProvider>
+        <BasicInfoStep
+          values={mockValues}
+          onValueChange={mockOnChange}
+          errors={mockErrors}
+        />
+      </SiteFormProvider>
     );
 
     // The helper text is now part of the label, not a separate element with a testid

--- a/tests/admin/sites/components/BasicInfoStep.validation.test.tsx
+++ b/tests/admin/sites/components/BasicInfoStep.validation.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import BasicInfoStep from '@/components/admin/sites/components/BasicInfoStep';
+import { SiteFormProvider } from '@/components/admin/sites/context/SiteFormContext';
 
 describe('BasicInfoStep Component - Validation', () => {
   // Mock form values
@@ -19,11 +20,13 @@ describe('BasicInfoStep Component - Validation', () => {
     };
 
     render(
-      <BasicInfoStep
-        values={mockValues}
-        onChange={mockOnChange}
-        errors={mockErrors}
-      />
+      <SiteFormProvider>
+        <BasicInfoStep
+          values={mockValues}
+          onValueChange={mockOnChange}
+          errors={mockErrors}
+        />
+      </SiteFormProvider>
     );
 
     // Check if error message is displayed
@@ -38,11 +41,13 @@ describe('BasicInfoStep Component - Validation', () => {
     };
 
     render(
-      <BasicInfoStep
-        values={mockValues}
-        onChange={mockOnChange}
-        errors={mockErrors}
-      />
+      <SiteFormProvider>
+        <BasicInfoStep
+          values={mockValues}
+          onValueChange={mockOnChange}
+          errors={mockErrors}
+        />
+      </SiteFormProvider>
     );
 
     // Check if error message is displayed
@@ -58,11 +63,13 @@ describe('BasicInfoStep Component - Validation', () => {
     };
 
     render(
-      <BasicInfoStep
-        values={mockValues}
-        onChange={mockOnChange}
-        errors={mockErrors}
-      />
+      <SiteFormProvider>
+        <BasicInfoStep
+          values={mockValues}
+          onValueChange={mockOnChange}
+          errors={mockErrors}
+        />
+      </SiteFormProvider>
     );
 
     // Check if input fields have error class
@@ -77,11 +84,13 @@ describe('BasicInfoStep Component - Validation', () => {
     const mockErrors = {};
 
     render(
-      <BasicInfoStep
-        values={mockValues}
-        onChange={mockOnChange}
-        errors={mockErrors}
-      />
+      <SiteFormProvider>
+        <BasicInfoStep
+          values={mockValues}
+          onValueChange={mockOnChange}
+          errors={mockErrors}
+        />
+      </SiteFormProvider>
     );
 
     // Error elements should not be in the document


### PR DESCRIPTION
This PR fixes the BasicInfoStep component and its tests:

1. Created a SiteFormContext to provide context for the BasicInfoStep component
2. Updated the BasicInfoStep component to work with both props and context
3. Updated the tests to wrap the component in a SiteFormProvider
4. Fixed prop names (onChange -> onValueChange, isLoading -> loading)
5. Added error handling for when the context is not available

These changes ensure that the tests pass and provide a better foundation for future development.